### PR TITLE
feat: normalize postal code before sending getAddress request

### DIFF
--- a/src/v1/__tests__/test.ts
+++ b/src/v1/__tests__/test.ts
@@ -110,6 +110,33 @@ test.each([
   expect(result).toEqual(fixture);
 });
 
+test('getAddress method: normalize postal code before sending request', async () => {
+  const fixture = {
+    version: '2020-08-31',
+    data: [],
+  };
+  const mockedAxiosGet = jest.fn();
+  mocked(axios).create = jest.fn(
+    (...args): AxiosInstance => {
+      const retval = jest.requireActual('axios').create(...args);
+      retval.get = mockedAxiosGet;
+      return retval;
+    }
+  );
+  mockedAxiosGet.mockResolvedValue({
+    data: fixture,
+  });
+  const ka = new KENALL('key');
+  await ka.getAddress('000-0000');
+  expect(mockedAxiosGet.mock.calls).toHaveLength(1);
+  expect(mockedAxiosGet.mock.calls[0][0]).toBe('/postalcode/0000000');
+  expect(mockedAxiosGet.mock.calls[0][1]).toEqual({
+    params: {
+      version: undefined,
+    },
+  });
+});
+
 test.each([
   {
     version: '2020-08-31',

--- a/src/v1/core.ts
+++ b/src/v1/core.ts
@@ -15,6 +15,14 @@ import {
 } from './interfaces';
 const DEFAULT_APIBASE_V1 = 'https://api.kenall.jp/v1';
 
+function normalizePostalCode(postalCode: string): string {
+  const match = postalCode.match(/^(\d{3})-(\d{4})$/);
+  if (match) {
+    return match[1] + match[2];
+  }
+  return postalCode;
+}
+
 export class KENALLV1 {
   private readonly axios: AxiosInstance;
   readonly apibase: string;
@@ -59,7 +67,7 @@ export class KENALLV1 {
     try {
       return validate<AddressResolverResponse>(
         await this.request(
-          `/postalcode/${postalCode}`,
+          `/postalcode/${normalizePostalCode(postalCode)}`,
           version != undefined ? { version: version } : {}
         )
       );


### PR DESCRIPTION
# 概要

郵便番号を間違ってXXX-XXXX形式で送ろうとしても送信前に修正するようにしました。