### PR TITLE
fix: searchNTACorporateInfo() must handle `mode` option.

### DIFF
--- a/src/v1/__tests__/test.ts
+++ b/src/v1/__tests__/test.ts
@@ -1,5 +1,5 @@
 import { mocked } from 'ts-jest/utils';
-import { KENALL } from '..';
+import { KENALL, NTACorporateInfoSearchMode } from '..';
 import { AxiosInstance } from 'axios';
 import axios from 'axios';
 
@@ -299,13 +299,18 @@ test.each([
     data: fixture,
   });
   const ka = new KENALL('key');
-  const options = { query: 'オープンコレクター', limit: 1 };
+  const options = {
+    query: 'オープンコレクター',
+    mode: 'exact' as NTACorporateInfoSearchMode,
+    limit: 1,
+  };
   const result = await ka.searchNTACorporateInfo(options);
   expect(mockedAxiosGet.mock.calls).toHaveLength(1);
   expect(mockedAxiosGet.mock.calls[0][0]).toBe('/houjinbangou');
   expect(mockedAxiosGet.mock.calls[0][1]).toEqual({
     params: {
       q: 'オープンコレクター',
+      mode: 'exact',
       limit: '1',
     },
   });

--- a/src/v1/core.ts
+++ b/src/v1/core.ts
@@ -192,6 +192,9 @@ export class KENALLV1 {
     if (options.query !== undefined) {
       params['q'] = options.query;
     }
+    if (options.mode !== undefined) {
+      params['mode'] = options.mode;
+    }
     if (options.offset !== undefined) {
       params['offset'] = String(options.offset | 0);
     }

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -13,6 +13,7 @@ export {
   NTACorporateInfoKind,
   NTACorporateInfoProcess,
   NTACorporateInfoResolverResponse,
+  NTACorporateInfoSearchMode,
   NTACorporateInfoSearcherOptions,
   NTACorporateInfoFacets,
   NTACorporateInfoSearcherResponse,

--- a/src/v1/interfaces.ts
+++ b/src/v1/interfaces.ts
@@ -869,6 +869,11 @@ export interface NTACorporateInfoResolverResponse {
   data: NTACorporateInfo;
 }
 
+export type NTACorporateInfoSearchMode =
+  | 'exact'
+  | 'partial'
+  | 'exact_with_kind';
+
 /**
  * An `NTACorporateInfoSearcherOptions` stores a set of parameters
  * that will be sent to `searchCorporateInfo` API.
@@ -909,7 +914,7 @@ export interface NTACorporateInfoSearcherOptions {
    *
    * Example: `"exact"`
    */
-  mode?: string | undefined;
+  mode?: NTACorporateInfoSearchMode | undefined;
 
   /**
    * The facet representation at which level the resulting facets


### PR DESCRIPTION
## 概要

* APIの側は `mode` に対応しているのにもかかわらず、JavaScript SDKの対応が未であった。
    https://kenall.jp/docs/API/houjinbangou/#%E6%A4%9C%E7%B4%A2%E3%83%A2%E3%83%BC%E3%83%89