### PR TITLE
feat: `unprocessedAddressLine` option to `AddressSearcherOptions`.

### DIFF
--- a/src/v1/__tests__/test.ts
+++ b/src/v1/__tests__/test.ts
@@ -505,49 +505,121 @@ test.each([
 
 test.each([
   {
-    version: '2021-09-15',
-    data: [
-      {
-        jisx0402: '13101',
-        old_code: '102',
-        postal_code: '1020083',
-        prefecture: '東京都',
-        prefecture_kana: 'トウキョウト',
-        city: '千代田区',
-        city_kana: 'チヨダク',
-        town: '麹町',
-        town_kana: 'コウジマチ',
-        town_raw: '麹町',
-        town_kana_raw: 'コウジマチ',
-        koaza: '',
-        kyoto_street: '',
-        building: '',
-        floor: '',
-        town_partial: false,
-        town_chome: false,
-        town_addressed_koaza: false,
-        town_multi: false,
-        corporation: null,
+    expected: {
+      secondArg: {
+        params: {
+          q: '東京都 千代田区 麹町',
+          limit: '1',
+        },
       },
-    ],
-    query: {
-      raw: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
-      prefecture: '東京都',
-      county: null,
-      city: '千代田区',
-      city_ward: null,
-      town: '麹町',
-      kyoto_street: null,
-      block_lot_num: '3-12-14',
-      building: '麹町駅前ヒルトップ',
-      floor_room: '8F',
     },
-    count: 1,
-    offset: 0,
-    limit: 1,
-    facets: null,
+    options: {
+      query: '東京都 千代田区 麹町',
+      limit: 1,
+    },
+    fixture: {
+      version: '2021-09-15',
+      data: [
+        {
+          jisx0402: '13101',
+          old_code: '102',
+          postal_code: '1020083',
+          prefecture: '東京都',
+          prefecture_kana: 'トウキョウト',
+          city: '千代田区',
+          city_kana: 'チヨダク',
+          town: '麹町',
+          town_kana: 'コウジマチ',
+          town_raw: '麹町',
+          town_kana_raw: 'コウジマチ',
+          koaza: '',
+          kyoto_street: '',
+          building: '',
+          floor: '',
+          town_partial: false,
+          town_chome: false,
+          town_addressed_koaza: false,
+          town_multi: false,
+          corporation: null,
+        },
+      ],
+      query: {
+        raw: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
+        prefecture: '東京都',
+        county: null,
+        city: '千代田区',
+        city_ward: null,
+        town: '麹町',
+        kyoto_street: null,
+        block_lot_num: '3-12-14',
+        building: '麹町駅前ヒルトップ',
+        floor_room: '8F',
+      },
+      count: 1,
+      offset: 0,
+      limit: 1,
+      facets: null,
+    },
   },
-])('searchAddresses method', async (fixture) => {
+  {
+    expected: {
+      secondArg: {
+        params: {
+          t: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
+          limit: '1',
+        },
+      },
+    },
+    options: {
+      unprocessedAddressLine:
+        '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
+      limit: 1,
+    },
+    fixture: {
+      version: '2021-09-15',
+      data: [
+        {
+          jisx0402: '13101',
+          old_code: '102',
+          postal_code: '1020083',
+          prefecture: '東京都',
+          prefecture_kana: 'トウキョウト',
+          city: '千代田区',
+          city_kana: 'チヨダク',
+          town: '麹町',
+          town_kana: 'コウジマチ',
+          town_raw: '麹町',
+          town_kana_raw: 'コウジマチ',
+          koaza: '',
+          kyoto_street: '',
+          building: '',
+          floor: '',
+          town_partial: false,
+          town_chome: false,
+          town_addressed_koaza: false,
+          town_multi: false,
+          corporation: null,
+        },
+      ],
+      query: {
+        raw: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
+        prefecture: '東京都',
+        county: null,
+        city: '千代田区',
+        city_ward: null,
+        town: '麹町',
+        kyoto_street: null,
+        block_lot_num: '3-12-14',
+        building: '麹町駅前ヒルトップ',
+        floor_room: '8F',
+      },
+      count: 1,
+      offset: 0,
+      limit: 1,
+      facets: null,
+    },
+  },
+])('searchAddresses method', async ({ expected, options, fixture }) => {
   const mockedAxiosGet = jest.fn();
   mocked(axios).create = jest.fn((...args): AxiosInstance => {
     const retval = jest.requireActual('axios').create(...args);
@@ -558,18 +630,9 @@ test.each([
     data: fixture,
   });
   const ka = new KENALL('key');
-  const options = {
-    query: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
-    limit: 1,
-  };
   const result = await ka.searchAddresses(options);
   expect(mockedAxiosGet.mock.calls).toHaveLength(1);
   expect(mockedAxiosGet.mock.calls[0][0]).toBe('/postalcode/');
-  expect(mockedAxiosGet.mock.calls[0][1]).toEqual({
-    params: {
-      q: '東京都千代田区麹町三丁目12-14麹町駅前ヒルトップ8F',
-      limit: '1',
-    },
-  });
+  expect(mockedAxiosGet.mock.calls[0][1]).toEqual(expected.secondArg);
   expect(result).toEqual(fixture);
 });

--- a/src/v1/core.ts
+++ b/src/v1/core.ts
@@ -129,6 +129,9 @@ export class KENALLV1 {
     if (options.query !== undefined) {
       params['q'] = options.query;
     }
+    if (options.unprocessedAddressLine !== undefined) {
+      params['t'] = options.unprocessedAddressLine;
+    }
     if (options.offset !== undefined) {
       params['offset'] = String(options.offset | 0);
     }

--- a/src/v1/interfaces.ts
+++ b/src/v1/interfaces.ts
@@ -399,9 +399,20 @@ export interface AddressSearcherOptions {
   /**
    * The query to search against the address database.
    *
+   * Either `query` or `unprocessedAddressLine` must be present.
+   *
    * Example: `"東京都 AND 渋谷区"`
    */
-  query: string | undefined;
+  query?: string;
+
+  /**
+   * The unprocessed portions of the address string to search against the address database.
+   *
+   * Either `query` or `unprocessedAddressLine` must be present.
+   *
+   * Example: `"東京都渋谷区初台"`
+   */
+  unprocessedAddressLine?: string;
 
   /**
    * The offset from which you want to retrieve the result.

--- a/translations/base/v1/AddressSearcherOptions.json
+++ b/translations/base/v1/AddressSearcherOptions.json
@@ -9,8 +9,17 @@
         "properties": {
             "query": {
                 "comment": {
-                    "text": "Example: `\"東京都 AND 渋谷区\"`",
+                    "text": [
+                        "Either `query` or `unprocessedAddressLine` must be present.",
+                        "Example: `\"東京都 AND 渋谷区\"`"
+                    ],
                     "shortText": "The query to search against the address database."
+                }
+            },
+            "unprocessedAddressLine": {
+                "comment": {
+                    "text": "Example: `\"東京都渋谷区初台\"`",
+                    "shortText": "The unprocessed portions of the address string to search against the address database."
                 }
             },
             "offset": {

--- a/translations/ja/v1/AddressSearcherOptions.json
+++ b/translations/ja/v1/AddressSearcherOptions.json
@@ -9,8 +9,20 @@
         "properties": {
             "query": {
                 "comment": {
-                    "text": "例: `\"東京都 AND 渋谷区\"`",
+                    "text": [
+                        "`query`あるいは`unprocessedAddressLine`のいずれかを必ず指定すうようにします。",
+                        "例: `\"東京都 AND 渋谷区\"`"
+                    ],
                     "shortText": "住所データベースに対して検索する問い合わせ文。"
+                }
+            },
+            "unprocessedAddressLine": {
+                "comment": {
+                    "text": [
+                        "`query`あるいは`unprocessedAddressLine`のいずれかを必ず指定すうようにします。",
+                        "Example: `\"東京都渋谷区初台\"`"
+                    ],
+                    "shortText": "住所データベースに対して検索を行う、未処理の住所文字列。"
                 }
             },
             "offset": {


### PR DESCRIPTION
## Summary

* This patch adds a missing option (`unprocessedAddressLine`) that corresponds to `t` query parameter of the upcoming search API.
