### PR TITLE
Update ttypescript version to 1.5.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
-        "ttypescript": "^1.5.13",
+        "ttypescript": "^1.5.15",
         "typedoc": "^0.22.0",
         "typedoc-plugin-localization": "^2.3.0",
         "typescript": "4.4.x"
@@ -12921,9 +12921,9 @@
       "dev": true
     },
     "node_modules/ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "dependencies": {
         "resolve": ">=1.9.0"
@@ -23608,9 +23608,9 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.13.tgz",
-      "integrity": "sha512-KT/RBfGGlVJFqEI8cVvI3nMsmYcFvPSZh8bU0qX+pAwbi7/ABmYkzn7l/K8skw0xmYjVCoyaV6WLsBQxdadybQ==",
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.15.tgz",
+      "integrity": "sha512-48ykDNHzFnPMnv4hYX1P8Q84TvCZyL1QlFxeuxsuZ48X2+ameBgPenvmCkHJtoOSxpoWTWi8NcgNrRnVDOmfSg==",
       "dev": true,
       "requires": {
         "resolve": ">=1.9.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",
     "tslib": "^2.3.1",
-    "ttypescript": "^1.5.13",
+    "ttypescript": "^1.5.15",
     "typedoc": "^0.22.0",
     "typedoc-plugin-localization": "^2.3.0",
     "typescript": "4.4.x"


### PR DESCRIPTION
# summary
This pull request aims to update the ttypescript version in our project from 1.5.13 to 1.5.15. The primary purpose of this update is to resolve the errors encountered during the execution of 'npm run test'. By upgrading to version 1.5.15, we anticipate improved stability and performance, which should directly address the testing issues.
