### PR TITLE
fix: improve typedoc

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/v1", "src"],
+  "entryPoints": ["src/v1", "src", "src/v1/validators.ts"],
   "excludePrivate": true,
   "theme": "default",
   "out": "built/docs",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/index.ts"],
+  "entryPoints": ["src/v1", "src"],
   "excludePrivate": true,
   "theme": "default",
   "out": "built/docs",


### PR DESCRIPTION
## 概要

* entrypointに `src/v1` を追加し、これまでドキュメントに含まれていなかった型が含まれるようにした。
* entrypointに `src/v1/validators.ts` を追加し、typedoc の warning を抑制した。