### PR TITLE
chore: remove unnecessary fetch input log

### DIFF
--- a/src/v1/fetch_shim.ts
+++ b/src/v1/fetch_shim.ts
@@ -178,10 +178,6 @@ export const buildAugmentedFetch =
             ...init_,
             headers: mergeHeaders(init_.headers, input.headers),
           } as RequestInitExt);
-    console.log(
-      typeof input === 'object' && !(input instanceof URL) ? { ...input } : '*',
-      init_
-    );
     try {
       const resp = await fetch(req);
       if (!resp.ok && throwErrorsForNon2xx) {


### PR DESCRIPTION
## 概要

- 2.3.0 ではfetchのタイミングで`console.log`を実行する形式になっており、APIを実行するとブラウザのコンソールログに表示されます。ログの表示は動作には必須の振る舞いではなく、利用側からすると不要なログなので該当箇所を削除します。
    - <img width="1282" height="430" alt="スクリーンショット 2026-04-14 13 27 42" src="https://github.com/user-attachments/assets/ec3d97d8-02c1-4112-ba2d-769464763a85" />