### PR TITLE
feat: implement whoami, holidays, business-day, and school-code SDK methods

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,5 +30,17 @@ export {
   BankResolverResponse,
   BankBranchesResponse,
   BankBranchResolverResponse,
+  RemoteAddress,
+  WhoamiResponse,
+  Holiday,
+  HolidaysOptions,
+  HolidaysResponse,
+  BusinessDayCheckResponse,
+  SchoolAddress,
+  School,
+  SchoolResolverResponse,
+  SchoolFacets,
+  SchoolSearcherOptions,
+  SchoolSearcherResponse,
 } from './v1/index.js';
 export { Config } from './config.js';

--- a/src/v1/__tests__/businessday_api.ts
+++ b/src/v1/__tests__/businessday_api.ts
@@ -1,0 +1,28 @@
+import { expect, test, vi } from 'vitest';
+
+import { KENALL } from '..';
+import { buildAugmentedFetch } from '../fetch_shim';
+
+vi.mock('../fetch_shim.js');
+
+const businessDayCheckResponse = [{ result: false }, { result: true }];
+
+test.each(
+  businessDayCheckResponse
+)('checkBusinessDay method', async (fixture) => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.checkBusinessDay('2026-01-01');
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe('./businessdays/check');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: { date: '2026-01-01' },
+  });
+  expect(result).toEqual(fixture);
+});

--- a/src/v1/__tests__/holidays_api.ts
+++ b/src/v1/__tests__/holidays_api.ts
@@ -1,0 +1,78 @@
+import { expect, test, vi } from 'vitest';
+
+import { KENALL } from '..';
+import { buildAugmentedFetch } from '../fetch_shim';
+
+vi.mock('../fetch_shim.js');
+
+const holidaysResponse = {
+  data: [
+    {
+      title: '元日',
+      date: '2022-01-01',
+      day_of_week: 6,
+      day_of_week_text: 'saturday',
+    },
+    {
+      title: '成人の日',
+      date: '2022-01-10',
+      day_of_week: 1,
+      day_of_week_text: 'monday',
+    },
+  ],
+};
+
+test('getHolidays method with year', async () => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(holidaysResponse),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.getHolidays({ year: 2026 });
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe('./holidays');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: { year: '2026' },
+  });
+  expect(result).toEqual(holidaysResponse);
+});
+
+test('getHolidays method with from/to', async () => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(holidaysResponse),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.getHolidays({
+    from: '2000-01-01',
+    to: '2001-02-01',
+  });
+  expect(mockFetch.mock.calls[0][0]).toBe('./holidays');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: { from: '2000-01-01', to: '2001-02-01' },
+  });
+  expect(result).toEqual(holidaysResponse);
+});
+
+test('getHolidays method without arguments', async () => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(holidaysResponse),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.getHolidays();
+  expect(mockFetch.mock.calls[0][0]).toBe('./holidays');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: {},
+  });
+  expect(result).toEqual(holidaysResponse);
+});

--- a/src/v1/__tests__/school_api.ts
+++ b/src/v1/__tests__/school_api.ts
@@ -1,0 +1,97 @@
+import { expect, test, vi } from 'vitest';
+
+import { KENALL } from '..';
+import { buildAugmentedFetch } from '../fetch_shim';
+
+vi.mock('../fetch_shim.js');
+
+const school = {
+  code: 'F113110102700',
+  type: 'F1',
+  jurisdiction_prefecture_code: '13',
+  establishment_type: 1,
+  branch: 1,
+  name: '東京大学',
+  address_raw: '東京都文京区本郷７－３－１',
+  addresses: [
+    {
+      postal_code: '1130033',
+      jisx0402: '13105',
+      prefecture: '東京都',
+      prefecture_kana: 'トウキョウト',
+      prefecture_roman: 'Tokyo',
+      city: '文京区',
+      city_kana: 'ブンキョウク',
+      city_roman: 'Bunkyo-ku',
+      street_number: '本郷7-3-1',
+      town: '本郷',
+      kyoto_street: null,
+      block_lot_num: '7-3-1',
+      building: null,
+      floor_room: null,
+    },
+  ],
+  established_date: '2021-01-20',
+  abolished_date: null,
+  school_survey_number: '0172',
+  new_code: [],
+};
+
+const schoolResolverResponse = {
+  version: '2024-08-28',
+  data: school,
+};
+
+const schoolSearcherResponse = {
+  version: '2024-08-28',
+  data: [school],
+  query: 'name:東京大学',
+  count: 1,
+  offset: 0,
+  limit: 100,
+  facets: {
+    area: [['/東京都', 1]],
+    type: [['/大学', 1]],
+    establishment_type: [['/公立', 1]],
+    branch: [['/本校', 1]],
+  },
+};
+
+test('getSchool method', async () => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(schoolResolverResponse),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.getSchool('F113110102700');
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe('./school/F113110102700');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: {},
+  });
+  expect(result).toEqual(schoolResolverResponse);
+});
+
+test('searchSchool method', async () => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(schoolSearcherResponse),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.searchSchool({
+    q: 'name:東京大学',
+    facet_area: '/東京都',
+  });
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe('./school/');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: { q: 'name:東京大学', facet_area: '/東京都' },
+  });
+  expect(result).toEqual(schoolSearcherResponse);
+});

--- a/src/v1/__tests__/whoami_api.ts
+++ b/src/v1/__tests__/whoami_api.ts
@@ -1,0 +1,33 @@
+import { expect, test, vi } from 'vitest';
+
+import { KENALL } from '..';
+import { buildAugmentedFetch } from '../fetch_shim';
+
+vi.mock('../fetch_shim.js');
+
+const whoamiResponse = [
+  {
+    remote_addr: {
+      type: 'v4',
+      address: '192.0.2.1',
+    },
+  },
+];
+
+test.each(whoamiResponse)('whoami method', async (fixture) => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
+  } as unknown as Response);
+  const ka = new KENALL('key');
+  const result = await ka.whoami();
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe('./whoami');
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: {},
+  });
+  expect(result).toEqual(fixture);
+});

--- a/src/v1/core.ts
+++ b/src/v1/core.ts
@@ -1,9 +1,23 @@
-import { ZodError } from 'zod';
+import { ZodError, type ZodType } from 'zod';
 import type { Config } from '../config.js';
 import type {
   AddressSearcherOptions,
+  BusinessDayCheckResponse,
+  HolidaysOptions,
+  HolidaysResponse,
   NTACorporateInfoSearcherOptions,
+  SchoolResolverResponse,
+  SchoolSearcherOptions,
+  SchoolSearcherResponse,
+  WhoamiResponse,
 } from './interfaces.compatible.js';
+import {
+  businessDayCheckResponseSchema,
+  holidaysResponseSchema,
+  schoolResolverResponseSchema,
+  schoolSearcherResponseSchema,
+  whoamiResponseSchema,
+} from './schemas.compatible.js';
 import type {
   APIVersion,
   AddressResolverResponseForVersion,
@@ -69,6 +83,23 @@ export class KENALLV1 {
       headers: { ...(apiVersion ? { 'KenAll-API-Version': apiVersion } : {}) },
     });
     return await r.json();
+  }
+
+  /**
+   * Validates the response payload against the given schema, converting a
+   * {@link ZodError} into a plain {@link Error} for a consistent error surface.
+   */
+  private validate<T>(schema: ZodType<T>, payload: unknown): T {
+    try {
+      return schema.parse(payload);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        throw new Error(
+          `invalid response payload: ${e.issues.map((i) => `${i.path}: ${i.message}`).join(', ')}`
+        );
+      }
+      throw e;
+    }
   }
 
   /**
@@ -423,5 +454,107 @@ export class KENALLV1 {
       }
       throw e;
     }
+  }
+
+  /**
+   * Invokes "whoami" API (endpoint: `/whoami`).
+   *
+   * This API is not versioned.
+   *
+   * @returns A {@link WhoamiResponse} that contains the IP address the request
+   *          was made from.
+   */
+  async whoami(): Promise<WhoamiResponse> {
+    const resp = await this.request('./whoami');
+    return this.validate(whoamiResponseSchema, resp);
+  }
+
+  /**
+   * Invokes "getHolidays" API (endpoint: `/holidays`).
+   *
+   * This API is not versioned.
+   *
+   * @param options The query. When `year` is given, `from` and `to` are
+   *                ignored and the whole year is returned.
+   * @returns A {@link HolidaysResponse}.
+   */
+  async getHolidays(options: HolidaysOptions = {}): Promise<HolidaysResponse> {
+    const params: { [k: string]: string } = {};
+    if (options.year !== undefined) {
+      params.year = String(options.year);
+    }
+    if (options.from !== undefined) {
+      params.from = options.from;
+    }
+    if (options.to !== undefined) {
+      params.to = options.to;
+    }
+    const resp = await this.request('./holidays', params);
+    return this.validate(holidaysResponseSchema, resp);
+  }
+
+  /**
+   * Invokes "checkBusinessDay" API (endpoint: `/businessdays/check`).
+   *
+   * This API is not versioned.
+   *
+   * @param date The date to check, in the form of `"YYYY-MM-DD"`.
+   * @returns A {@link BusinessDayCheckResponse}.
+   */
+  async checkBusinessDay(date: string): Promise<BusinessDayCheckResponse> {
+    const resp = await this.request('./businessdays/check', { date: date });
+    return this.validate(businessDayCheckResponseSchema, resp);
+  }
+
+  /**
+   * Invokes "getSchool" API (endpoint: `/school/{schoolCode}`).
+   *
+   * This API is not versioned.
+   *
+   * @param schoolCode The 13 digit school code to query with.
+   * @returns A {@link SchoolResolverResponse}.
+   */
+  async getSchool(schoolCode: string): Promise<SchoolResolverResponse> {
+    const resp = await this.request(
+      `./school/${encodeURIComponent(schoolCode)}`
+    );
+    return this.validate(schoolResolverResponseSchema, resp);
+  }
+
+  /**
+   * Invokes "searchSchool" API (endpoint: `/school/?...`).
+   *
+   * This API is not versioned.
+   *
+   * @param options The query.
+   * @returns A {@link SchoolSearcherResponse}.
+   */
+  async searchSchool(
+    options: SchoolSearcherOptions
+  ): Promise<SchoolSearcherResponse> {
+    const params: { [k: string]: string } = { q: options.q };
+    if (options.offset !== undefined) {
+      params.offset = String(options.offset | 0);
+    }
+    if (options.limit !== undefined) {
+      params.limit = String(options.limit | 0);
+    }
+    if (options.facet_area !== undefined) {
+      params.facet_area = options.facet_area;
+    }
+    if (options.facet_prefecture !== undefined) {
+      params.facet_prefecture = options.facet_prefecture;
+    }
+    if (options.facet_type !== undefined) {
+      params.facet_type = options.facet_type;
+    }
+    if (options.facet_establishment_type !== undefined) {
+      params.facet_establishment_type = options.facet_establishment_type;
+    }
+    if (options.facet_branch !== undefined) {
+      params.facet_branch = options.facet_branch;
+    }
+    const resp = await this.request('./school/', params);
+    return this.validate(schoolSearcherResponseSchema, resp);
   }
 }

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -30,6 +30,18 @@ export {
   NTAQualifiedInvoiceIssuerKind,
   NTAQualifiedInvoiceIssuerProcess,
   NTAQualifiedInvoiceIssuerInfoResolverResponse,
+  RemoteAddress,
+  WhoamiResponse,
+  Holiday,
+  HolidaysOptions,
+  HolidaysResponse,
+  BusinessDayCheckResponse,
+  SchoolAddress,
+  School,
+  SchoolResolverResponse,
+  SchoolFacets,
+  SchoolSearcherOptions,
+  SchoolSearcherResponse,
 } from './interfaces.compatible.js';
 export * as v20221101 from './interfaces.v20221101.js';
 export * as v20220901 from './interfaces.v20220901.js';

--- a/src/v1/interfaces.compatible.ts
+++ b/src/v1/interfaces.compatible.ts
@@ -1,6 +1,7 @@
 import type * as v20221101 from './interfaces.v20221101.js';
 import type * as v20230901 from './interfaces.v20230901.js';
 import type * as v20240101 from './interfaces.v20240101.js';
+import type * as v20250101 from './interfaces.v20250101.js';
 
 export type UpdateStatus = v20221101.UpdateStatus;
 export type UpdateReason = v20221101.UpdateReason;
@@ -37,6 +38,18 @@ export type BanksResponse = v20230901.BanksResponse;
 export type BankResolverResponse = v20230901.BankResolverResponse;
 export type BankBranchesResponse = v20230901.BankBranchesResponse;
 export type BankBranchResolverResponse = v20230901.BankBranchResolverResponse;
+export type RemoteAddress = v20250101.RemoteAddress;
+export type WhoamiResponse = v20250101.WhoamiResponse;
+export type Holiday = v20250101.Holiday;
+export type HolidaysOptions = v20250101.HolidaysOptions;
+export type HolidaysResponse = v20250101.HolidaysResponse;
+export type BusinessDayCheckResponse = v20250101.BusinessDayCheckResponse;
+export type SchoolAddress = v20250101.SchoolAddress;
+export type School = v20250101.School;
+export type SchoolResolverResponse = v20250101.SchoolResolverResponse;
+export type SchoolFacets = v20250101.SchoolFacets;
+export type SchoolSearcherOptions = v20250101.SchoolSearcherOptions;
+export type SchoolSearcherResponse = v20250101.SchoolSearcherResponse;
 
 /**
  * A `Corporation` object would store the information about the organization,

--- a/src/v1/interfaces.v20221101.ts
+++ b/src/v1/interfaces.v20221101.ts
@@ -1,3 +1,5 @@
+import type * as v20250101 from './interfaces.v20250101.js';
+
 /**
  * A `Corporation` object would store the information about the organization,
  * or the division of a organization, which has its special postal code designated.
@@ -1377,3 +1379,10 @@ export interface NTACorporateInfoSearcherResponse {
    */
   facets: NTACorporateInfoFacets | null;
 }
+
+export type RemoteAddress = v20250101.RemoteAddress;
+export type WhoamiResponse = v20250101.WhoamiResponse;
+export type Holiday = v20250101.Holiday;
+export type HolidaysOptions = v20250101.HolidaysOptions;
+export type HolidaysResponse = v20250101.HolidaysResponse;
+export type BusinessDayCheckResponse = v20250101.BusinessDayCheckResponse;

--- a/src/v1/interfaces.v20230901.ts
+++ b/src/v1/interfaces.v20230901.ts
@@ -1,3 +1,5 @@
+import type * as v20250101 from './interfaces.v20250101.js';
+
 /**
  * A `Corporation` object would store the information about the organization,
  * or the division of a organization, which has its special postal code designated.
@@ -1608,3 +1610,10 @@ export interface NTACorporateInfoSearcherResponse {
    */
   facets: NTACorporateInfoFacets | null;
 }
+
+export type RemoteAddress = v20250101.RemoteAddress;
+export type WhoamiResponse = v20250101.WhoamiResponse;
+export type Holiday = v20250101.Holiday;
+export type HolidaysOptions = v20250101.HolidaysOptions;
+export type HolidaysResponse = v20250101.HolidaysResponse;
+export type BusinessDayCheckResponse = v20250101.BusinessDayCheckResponse;

--- a/src/v1/interfaces.v20240101.ts
+++ b/src/v1/interfaces.v20240101.ts
@@ -1,3 +1,5 @@
+import type * as v20250101 from './interfaces.v20250101.js';
+
 /**
  * A `Corporation` object would store the information about the organization,
  * or the division of a organization, which has its special postal code designated.
@@ -1908,3 +1910,16 @@ export interface NTAQualifiedInvoiceIssuerInfoResolverResponse {
    */
   data: NTAQualifiedInvoiceIssuerInfo;
 }
+
+export type RemoteAddress = v20250101.RemoteAddress;
+export type WhoamiResponse = v20250101.WhoamiResponse;
+export type Holiday = v20250101.Holiday;
+export type HolidaysOptions = v20250101.HolidaysOptions;
+export type HolidaysResponse = v20250101.HolidaysResponse;
+export type BusinessDayCheckResponse = v20250101.BusinessDayCheckResponse;
+export type SchoolAddress = v20250101.SchoolAddress;
+export type School = v20250101.School;
+export type SchoolResolverResponse = v20250101.SchoolResolverResponse;
+export type SchoolFacets = v20250101.SchoolFacets;
+export type SchoolSearcherOptions = v20250101.SchoolSearcherOptions;
+export type SchoolSearcherResponse = v20250101.SchoolSearcherResponse;

--- a/src/v1/interfaces.v20250101.ts
+++ b/src/v1/interfaces.v20250101.ts
@@ -1908,3 +1908,432 @@ export interface NTAQualifiedInvoiceIssuerInfoResolverResponse {
    */
   data: NTAQualifiedInvoiceIssuerInfo;
 }
+
+/**
+ * A `RemoteAddress` object stores the IP address the request originated from,
+ * as observed by the API server.
+ */
+export interface RemoteAddress {
+  /**
+   * The kind of the IP address.
+   *
+   * * `"v4"` for an IPv4 address
+   * * `"v6"` for an IPv6 address
+   */
+  type: 'v4' | 'v6';
+
+  /**
+   * The IP address in its textual representation.
+   *
+   * Example: `"192.0.2.1"`
+   */
+  address: string;
+}
+
+/**
+ * A `WhoamiResponse` describes a response to `whoami` API call.
+ */
+export interface WhoamiResponse {
+  /**
+   * The IP address the request was made from.
+   */
+  remote_addr: RemoteAddress;
+}
+
+/**
+ * A `Holiday` object represents a single public holiday in Japan.
+ */
+export interface Holiday {
+  /**
+   * The name of the holiday.
+   *
+   * Example: `"元日"`
+   */
+  title: string;
+
+  /**
+   * The date of the holiday, in the form of `"YYYY-MM-DD"`.
+   *
+   * Example: `"2022-01-01"`
+   */
+  date: string;
+
+  /**
+   * The day of the week, represented as a number where
+   * `0` is Sunday and `6` is Saturday.
+   */
+  day_of_week: number;
+
+  /**
+   * The day of the week, spelled out in lowercase English.
+   *
+   * Example: `"saturday"`
+   */
+  day_of_week_text: string;
+}
+
+/**
+ * The set of options that can be passed to `getHolidays`.
+ *
+ * When `year` is specified, `from` and `to` are ignored and the whole year
+ * is returned. Otherwise the range designated by `from` and `to` is used.
+ */
+export interface HolidaysOptions {
+  /**
+   * The calendar year to retrieve the holidays for.
+   *
+   * Example: `2022`
+   */
+  year?: number | string;
+
+  /**
+   * The start of the range to retrieve the holidays for, inclusive,
+   * in the form of `"YYYY-MM-DD"`.
+   */
+  from?: string;
+
+  /**
+   * The end of the range to retrieve the holidays for, inclusive,
+   * in the form of `"YYYY-MM-DD"`.
+   */
+  to?: string;
+}
+
+/**
+ * A `HolidaysResponse` describes a response to `getHolidays` API call.
+ */
+export interface HolidaysResponse {
+  /**
+   * The list of the holidays that fall within the queried year or range.
+   */
+  data: Holiday[];
+}
+
+/**
+ * A `BusinessDayCheckResponse` describes a response to
+ * `checkBusinessDay` API call.
+ */
+export interface BusinessDayCheckResponse {
+  /**
+   * Whether the queried date is a business day, i.e. neither a weekend
+   * nor a public holiday.
+   */
+  result: boolean;
+}
+
+/**
+ * A `SchoolAddress` object stores the resolved address of a school.
+ */
+export interface SchoolAddress {
+  /**
+   * The postal code assigned to the location of the school.
+   */
+  postal_code: string;
+
+  /**
+   * The 5 digit Japanese municipality code (全国地方公共団体コード).
+   */
+  jisx0402: string;
+
+  /**
+   * The name of the prefecture in Kanji.
+   *
+   * Example: `"東京都"`
+   */
+  prefecture: string;
+
+  /**
+   * The reading of the name of the prefecture in katakana.
+   *
+   * Example: `"トウキョウト"`
+   */
+  prefecture_kana: string;
+
+  /**
+   * The "romanized" reading of the name of the prefecture.
+   *
+   * Example: `"Tokyo"`
+   */
+  prefecture_roman: string;
+
+  /**
+   * The name of the city.
+   *
+   * Example: `"文京区"`
+   */
+  city: string;
+
+  /**
+   * The reading of the name of the city in katakana.
+   *
+   * Example: `"ブンキョウク"`
+   */
+  city_kana: string;
+
+  /**
+   * The "romanized" reading of the name of the city.
+   *
+   * Example: `"Bunkyo-ku"`
+   */
+  city_roman: string;
+
+  /**
+   * The remaining part of the address below the city level.
+   *
+   * Example: `"本郷7-3-1"`
+   */
+  street_number: string;
+
+  /**
+   * The name of the town.
+   *
+   * Example: `"本郷"`
+   */
+  town: string;
+
+  /**
+   * The instructional phrase (通り名) specific to Kyoto city, if any.
+   */
+  kyoto_street: string | null;
+
+  /**
+   * The block and lot number part of the address.
+   *
+   * Example: `"7-3-1"`
+   */
+  block_lot_num: string;
+
+  /**
+   * The name of the building, if any.
+   */
+  building: string | null;
+
+  /**
+   * The floor and room part of the address, if any.
+   */
+  floor_room: string | null;
+}
+
+/**
+ * A `School` object stores the information about a school identified by
+ * a school code (学校コード) designated by MEXT.
+ */
+export interface School {
+  /**
+   * The 13 digit school code (学校コード).
+   *
+   * Example: `"F113110102700"`
+   */
+  code: string;
+
+  /**
+   * The school type code.
+   *
+   * Example: `"F1"`
+   */
+  type: string;
+
+  /**
+   * The prefecture code of the jurisdiction, defined in JISX0401.
+   *
+   * Example: `"13"`
+   */
+  jurisdiction_prefecture_code: string;
+
+  /**
+   * The establishment type code (設置区分).
+   */
+  establishment_type: number;
+
+  /**
+   * The branch code (本分校) where `1` denotes the main school.
+   */
+  branch: number;
+
+  /**
+   * The name of the school.
+   *
+   * Example: `"東京大学"`
+   */
+  name: string;
+
+  /**
+   * The raw, unprocessed address string of the school.
+   *
+   * Example: `"東京都文京区本郷７－３－１"`
+   */
+  address_raw: string;
+
+  /**
+   * The resolved addresses of the school.
+   */
+  addresses: SchoolAddress[];
+
+  /**
+   * The date the school was established, in the form of `"YYYY-MM-DD"`.
+   */
+  established_date: string;
+
+  /**
+   * The date the school was abolished, in the form of `"YYYY-MM-DD"`,
+   * or `null` if it is still active.
+   */
+  abolished_date: string | null;
+
+  /**
+   * The school survey number (学校調査番号).
+   */
+  school_survey_number: string;
+
+  /**
+   * The list of the school codes that superseded this school, if any.
+   */
+  new_code: string[];
+
+  /**
+   * A catch-all property
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * A `SchoolResolverResponse` describes a response to `getSchool` API call.
+ */
+export interface SchoolResolverResponse {
+  /**
+   * The version of the data, in the form of `"YYYY-MM-DD"`.
+   */
+  version: string;
+
+  /**
+   * The resolved school.
+   */
+  data: School;
+}
+
+/**
+ * A `SchoolFacets` represents the facets of a school search result.
+ *
+ * It is only available when at least one `facet_*` option is given,
+ * and each facet is a list of {@link Facet} tuples.
+ */
+export interface SchoolFacets {
+  /**
+   * The facet of the area (地域).
+   */
+  area?: Facet[];
+
+  /**
+   * The facet of the school type (学校種).
+   */
+  type?: Facet[];
+
+  /**
+   * The facet of the establishment type (設置区分).
+   */
+  establishment_type?: Facet[];
+
+  /**
+   * The facet of the branch (本分校).
+   */
+  branch?: Facet[];
+}
+
+/**
+ * The set of options that can be passed to `searchSchool`.
+ */
+export interface SchoolSearcherOptions {
+  /**
+   * The search query.
+   *
+   * Example: `"name:東京大学"`
+   */
+  q: string;
+
+  /**
+   * The offset from which the result has to be retrieved.
+   */
+  offset?: number;
+
+  /**
+   * The maximum number of the items to retrieve, between 1 and 100.
+   */
+  limit?: number;
+
+  /**
+   * The hierarchy of the area facet to narrow the result down to.
+   *
+   * Example: `"/東京都/文京区"`
+   */
+  facet_area?: string;
+
+  /**
+   * The hierarchy of the prefecture facet to narrow the result down to.
+   *
+   * Example: `"/東京都"`
+   */
+  facet_prefecture?: string;
+
+  /**
+   * The hierarchy of the school type facet to narrow the result down to.
+   *
+   * Example: `"/大学"`
+   */
+  facet_type?: string;
+
+  /**
+   * The hierarchy of the establishment type facet to narrow the result down to.
+   *
+   * Example: `"/公立"`
+   */
+  facet_establishment_type?: string;
+
+  /**
+   * The hierarchy of the branch facet to narrow the result down to.
+   *
+   * Example: `"/本校"`
+   */
+  facet_branch?: string;
+}
+
+/**
+ * A `SchoolSearcherResponse` describes a response to `searchSchool` API call.
+ */
+export interface SchoolSearcherResponse {
+  /**
+   * The version of the data, in the form of `"YYYY-MM-DD"`.
+   */
+  version: string;
+
+  /**
+   * The set of the schools that match to the query.
+   */
+  data: School[];
+
+  /**
+   * The query that the search has been performed for.
+   */
+  query: string;
+
+  /**
+   * The number of the resulting items in total.
+   */
+  count: number;
+
+  /**
+   * The offset from which the result has been retrieved.
+   */
+  offset: number;
+
+  /**
+   * The number of items that have been intended, at most, to retrieve.
+   */
+  limit: number;
+
+  /**
+   * The facets of the result that form with the query.
+   *
+   * If no facet is given, those will be unavailable and this stores null.
+   */
+  facets: SchoolFacets | null;
+}

--- a/src/v1/schemas.compatible.ts
+++ b/src/v1/schemas.compatible.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import * as v20221101 from './interfaces.v20221101.js';
 import * as v20221101S from './schemas.v20221101.js';
+import * as v20250101S from './schemas.v20250101.js';
 
 export const corporationSchema = v20221101S.corporationSchema;
 
@@ -79,3 +80,17 @@ export const cityResolverResponseSchema = z.object({
   version: z.string(),
   data: z.array(citySchema),
 });
+
+export const remoteAddressSchema = v20250101S.remoteAddressSchema;
+export const whoamiResponseSchema = v20250101S.whoamiResponseSchema;
+export const holidaySchema = v20250101S.holidaySchema;
+export const holidaysResponseSchema = v20250101S.holidaysResponseSchema;
+export const businessDayCheckResponseSchema =
+  v20250101S.businessDayCheckResponseSchema;
+export const schoolAddressSchema = v20250101S.schoolAddressSchema;
+export const schoolSchema = v20250101S.schoolSchema;
+export const schoolResolverResponseSchema =
+  v20250101S.schoolResolverResponseSchema;
+export const schoolFacetsSchema = v20250101S.schoolFacetsSchema;
+export const schoolSearcherResponseSchema =
+  v20250101S.schoolSearcherResponseSchema;

--- a/src/v1/schemas.v20221101.ts
+++ b/src/v1/schemas.v20221101.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import * as v20250101S from './schemas.v20250101.js';
+
 import {
   UpdateReason,
   UpdateStatus,
@@ -162,3 +164,10 @@ export const ntaCorporateInfoSearcherResponseSchema = z.object({
   limit: z.number(),
   facets: ntaCorporateInfoFacetsSchema.nullable(),
 });
+
+export const remoteAddressSchema = v20250101S.remoteAddressSchema;
+export const whoamiResponseSchema = v20250101S.whoamiResponseSchema;
+export const holidaySchema = v20250101S.holidaySchema;
+export const holidaysResponseSchema = v20250101S.holidaysResponseSchema;
+export const businessDayCheckResponseSchema =
+  v20250101S.businessDayCheckResponseSchema;

--- a/src/v1/schemas.v20230901.ts
+++ b/src/v1/schemas.v20230901.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import * as v20250101S from './schemas.v20250101.js';
+
 import {
   UpdateReason,
   UpdateStatus,
@@ -210,3 +212,10 @@ export const ntaCorporateInfoSearcherResponseSchema = z.object({
   limit: z.number(),
   facets: ntaCorporateInfoFacetsSchema.nullable(),
 });
+
+export const remoteAddressSchema = v20250101S.remoteAddressSchema;
+export const whoamiResponseSchema = v20250101S.whoamiResponseSchema;
+export const holidaySchema = v20250101S.holidaySchema;
+export const holidaysResponseSchema = v20250101S.holidaysResponseSchema;
+export const businessDayCheckResponseSchema =
+  v20250101S.businessDayCheckResponseSchema;

--- a/src/v1/schemas.v20240101.ts
+++ b/src/v1/schemas.v20240101.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import * as v20250101S from './schemas.v20250101.js';
+
 import {
   NTACorporateInfoCloseCause,
   NTACorporateInfoKind,
@@ -252,3 +254,17 @@ export const ntaQualifiedInvoiceIssuerInfoResolverResponseSchema = z.object({
   version: z.string(),
   data: ntaQualifiedInvoiceIssuerInfoSchema,
 });
+
+export const remoteAddressSchema = v20250101S.remoteAddressSchema;
+export const whoamiResponseSchema = v20250101S.whoamiResponseSchema;
+export const holidaySchema = v20250101S.holidaySchema;
+export const holidaysResponseSchema = v20250101S.holidaysResponseSchema;
+export const businessDayCheckResponseSchema =
+  v20250101S.businessDayCheckResponseSchema;
+export const schoolAddressSchema = v20250101S.schoolAddressSchema;
+export const schoolSchema = v20250101S.schoolSchema;
+export const schoolResolverResponseSchema =
+  v20250101S.schoolResolverResponseSchema;
+export const schoolFacetsSchema = v20250101S.schoolFacetsSchema;
+export const schoolSearcherResponseSchema =
+  v20250101S.schoolSearcherResponseSchema;

--- a/src/v1/schemas.v20250101.ts
+++ b/src/v1/schemas.v20250101.ts
@@ -252,3 +252,81 @@ export const ntaQualifiedInvoiceIssuerInfoResolverResponseSchema = z.object({
   version: z.string(),
   data: ntaQualifiedInvoiceIssuerInfoSchema,
 });
+
+export const remoteAddressSchema = z.object({
+  type: z.enum(['v4', 'v6']),
+  address: z.string(),
+});
+
+export const whoamiResponseSchema = z.object({
+  remote_addr: remoteAddressSchema,
+});
+
+export const holidaySchema = z.object({
+  title: z.string(),
+  date: z.string(),
+  day_of_week: z.number(),
+  day_of_week_text: z.string(),
+});
+
+export const holidaysResponseSchema = z.object({
+  data: z.array(holidaySchema),
+});
+
+export const businessDayCheckResponseSchema = z.object({
+  result: z.boolean(),
+});
+
+export const schoolAddressSchema = z.object({
+  postal_code: z.string(),
+  jisx0402: z.string(),
+  prefecture: z.string(),
+  prefecture_kana: z.string(),
+  prefecture_roman: z.string(),
+  city: z.string(),
+  city_kana: z.string(),
+  city_roman: z.string(),
+  street_number: z.string(),
+  town: z.string(),
+  kyoto_street: z.string().nullable(),
+  block_lot_num: z.string(),
+  building: z.string().nullable(),
+  floor_room: z.string().nullable(),
+});
+
+export const schoolSchema = z.object({
+  code: z.string(),
+  type: z.string(),
+  jurisdiction_prefecture_code: z.string(),
+  establishment_type: z.number(),
+  branch: z.number(),
+  name: z.string(),
+  address_raw: z.string(),
+  addresses: z.array(schoolAddressSchema),
+  established_date: z.string(),
+  abolished_date: z.string().nullable(),
+  school_survey_number: z.string(),
+  new_code: z.array(z.string()),
+});
+
+export const schoolResolverResponseSchema = z.object({
+  version: z.string(),
+  data: schoolSchema,
+});
+
+export const schoolFacetsSchema = z.object({
+  area: z.array(facetSchema).optional(),
+  type: z.array(facetSchema).optional(),
+  establishment_type: z.array(facetSchema).optional(),
+  branch: z.array(facetSchema).optional(),
+});
+
+export const schoolSearcherResponseSchema = z.object({
+  version: z.string(),
+  data: z.array(schoolSchema),
+  query: z.string(),
+  count: z.number(),
+  offset: z.number(),
+  limit: z.number(),
+  facets: schoolFacetsSchema.nullable(),
+});

--- a/translations/base/v1/BusinessDayCheckResponse.json
+++ b/translations/base/v1/BusinessDayCheckResponse.json
@@ -1,0 +1,45 @@
+{
+    "BusinessDayCheckResponse": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`BusinessDayCheckResponse`"
+                },
+                {
+                    "kind": "text",
+                    "text": " describes a response to\n"
+                },
+                {
+                    "kind": "code",
+                    "text": "`checkBusinessDay`"
+                },
+                {
+                    "kind": "text",
+                    "text": " API call."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "result": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Whether the queried date is a business day, i.e. neither a weekend\nnor a public holiday."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/Holiday.json
+++ b/translations/base/v1/Holiday.json
@@ -1,0 +1,109 @@
+{
+    "Holiday": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`Holiday`"
+                },
+                {
+                    "kind": "text",
+                    "text": " object represents a single public holiday in Japan."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "title": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the holiday.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"元日\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "date": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The date of the holiday, in the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ".\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"2022-01-01\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "day_of_week": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The day of the week, represented as a number where\n"
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`0`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " is Sunday and "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`6`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " is Saturday."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "day_of_week_text": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The day of the week, spelled out in lowercase English.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"saturday\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/HolidaysOptions.json
+++ b/translations/base/v1/HolidaysOptions.json
@@ -1,0 +1,121 @@
+{
+    "HolidaysOptions": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "The set of options that can be passed to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`getHolidays`"
+                },
+                {
+                    "kind": "text",
+                    "text": ".\n\nWhen "
+                },
+                {
+                    "kind": "code",
+                    "text": "`year`"
+                },
+                {
+                    "kind": "text",
+                    "text": " is specified, "
+                },
+                {
+                    "kind": "code",
+                    "text": "`from`"
+                },
+                {
+                    "kind": "text",
+                    "text": " and "
+                },
+                {
+                    "kind": "code",
+                    "text": "`to`"
+                },
+                {
+                    "kind": "text",
+                    "text": " are ignored and the whole year\nis returned. Otherwise the range designated by "
+                },
+                {
+                    "kind": "code",
+                    "text": "`from`"
+                },
+                {
+                    "kind": "text",
+                    "text": " and "
+                },
+                {
+                    "kind": "code",
+                    "text": "`to`"
+                },
+                {
+                    "kind": "text",
+                    "text": " is used."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "year": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The calendar year to retrieve the holidays for.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`2022`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "from": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The start of the range to retrieve the holidays for, inclusive,\nin the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "to": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The end of the range to retrieve the holidays for, inclusive,\nin the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/HolidaysResponse.json
+++ b/translations/base/v1/HolidaysResponse.json
@@ -1,0 +1,45 @@
+{
+    "HolidaysResponse": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`HolidaysResponse`"
+                },
+                {
+                    "kind": "text",
+                    "text": " describes a response to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`getHolidays`"
+                },
+                {
+                    "kind": "text",
+                    "text": " API call."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "data": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The list of the holidays that fall within the queried year or range."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/KENALL.json
+++ b/translations/base/v1/KENALL.json
@@ -414,6 +414,246 @@
                     ],
                     "modifierTags": {}
                 }
+            },
+            "whoami": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Invokes \"whoami\" API (endpoint: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`/whoami`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ").\n\nThis API is not versioned."
+                        }
+                    ],
+                    "blockTags": [
+                        {
+                            "tag": "@returns",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "A "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "WhoamiResponse",
+                                    "target": {
+                                        "packageName": "@ken-all/kenall",
+                                        "packagePath": "src/v1/interfaces.compatible.ts",
+                                        "qualifiedName": "WhoamiResponse",
+                                        "pos": 2200,
+                                        "transientId": null,
+                                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.compatible.ts"
+                                    }
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": " that contains the IP address the request\n         was made from."
+                                }
+                            ],
+                            "skipRendering": false
+                        }
+                    ],
+                    "modifierTags": {}
+                }
+            },
+            "getHolidays": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Invokes \"getHolidays\" API (endpoint: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`/holidays`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ").\n\nThis API is not versioned."
+                        }
+                    ],
+                    "blockTags": [
+                        {
+                            "tag": "@returns",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "A "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "HolidaysResponse",
+                                    "target": {
+                                        "packageName": "@ken-all/kenall",
+                                        "packagePath": "src/v1/interfaces.compatible.ts",
+                                        "qualifiedName": "HolidaysResponse",
+                                        "pos": 2353,
+                                        "transientId": null,
+                                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.compatible.ts"
+                                    }
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": "."
+                                }
+                            ],
+                            "skipRendering": false
+                        }
+                    ],
+                    "modifierTags": {}
+                }
+            },
+            "checkBusinessDay": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Invokes \"checkBusinessDay\" API (endpoint: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`/businessdays/check`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ").\n\nThis API is not versioned."
+                        }
+                    ],
+                    "blockTags": [
+                        {
+                            "tag": "@returns",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "A "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "BusinessDayCheckResponse",
+                                    "target": {
+                                        "packageName": "@ken-all/kenall",
+                                        "packagePath": "src/v1/interfaces.compatible.ts",
+                                        "qualifiedName": "BusinessDayCheckResponse",
+                                        "pos": 2412,
+                                        "transientId": null,
+                                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.compatible.ts"
+                                    }
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": "."
+                                }
+                            ],
+                            "skipRendering": false
+                        }
+                    ],
+                    "modifierTags": {}
+                }
+            },
+            "getSchool": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Invokes \"getSchool\" API (endpoint: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`/school/{schoolCode}`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ").\n\nThis API is not versioned."
+                        }
+                    ],
+                    "blockTags": [
+                        {
+                            "tag": "@returns",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "A "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "SchoolResolverResponse",
+                                    "target": {
+                                        "packageName": "@ken-all/kenall",
+                                        "packagePath": "src/v1/interfaces.compatible.ts",
+                                        "qualifiedName": "SchoolResolverResponse",
+                                        "pos": 2579,
+                                        "transientId": null,
+                                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.compatible.ts"
+                                    }
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": "."
+                                }
+                            ],
+                            "skipRendering": false
+                        }
+                    ],
+                    "modifierTags": {}
+                }
+            },
+            "searchSchool": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "Invokes \"searchSchool\" API (endpoint: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`/school/?...`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ").\n\nThis API is not versioned."
+                        }
+                    ],
+                    "blockTags": [
+                        {
+                            "tag": "@returns",
+                            "content": [
+                                {
+                                    "kind": "text",
+                                    "text": "A "
+                                },
+                                {
+                                    "kind": "inline-tag",
+                                    "tag": "@link",
+                                    "text": "SchoolSearcherResponse",
+                                    "target": {
+                                        "packageName": "@ken-all/kenall",
+                                        "packagePath": "src/v1/interfaces.compatible.ts",
+                                        "qualifiedName": "SchoolSearcherResponse",
+                                        "pos": 2770,
+                                        "transientId": null,
+                                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.compatible.ts"
+                                    }
+                                },
+                                {
+                                    "kind": "text",
+                                    "text": "."
+                                }
+                            ],
+                            "skipRendering": false
+                        }
+                    ],
+                    "modifierTags": {}
+                }
             }
         },
         "accessors": {}

--- a/translations/base/v1/RemoteAddress.json
+++ b/translations/base/v1/RemoteAddress.json
@@ -1,0 +1,69 @@
+{
+    "RemoteAddress": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`RemoteAddress`"
+                },
+                {
+                    "kind": "text",
+                    "text": " object stores the IP address the request originated from,\nas observed by the API server."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The kind of the IP address.\n\n* "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"v4\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " for an IPv4 address\n* "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"v6\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " for an IPv6 address"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "address": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The IP address in its textual representation.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"192.0.2.1\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/School.json
+++ b/translations/base/v1/School.json
@@ -1,0 +1,221 @@
+{
+    "School": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`School`"
+                },
+                {
+                    "kind": "text",
+                    "text": " object stores the information about a school identified by\na school code (学校コード) designated by MEXT."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "code": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The 13 digit school code (学校コード).\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"F113110102700\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The school type code.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"F1\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "jurisdiction_prefecture_code": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The prefecture code of the jurisdiction, defined in JISX0401.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"13\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "establishment_type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The establishment type code (設置区分)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "branch": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The branch code (本分校) where "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`1`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " denotes the main school."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "name": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the school.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"東京大学\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "address_raw": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The raw, unprocessed address string of the school.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"東京都文京区本郷７－３－１\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "addresses": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The resolved addresses of the school."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "established_date": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The date the school was established, in the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "abolished_date": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The date the school was abolished, in the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": ",\nor "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`null`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": " if it is still active."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "school_survey_number": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The school survey number (学校調査番号)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "new_code": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The list of the school codes that superseded this school, if any."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/SchoolAddress.json
+++ b/translations/base/v1/SchoolAddress.json
@@ -1,0 +1,229 @@
+{
+    "SchoolAddress": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`SchoolAddress`"
+                },
+                {
+                    "kind": "text",
+                    "text": " object stores the resolved address of a school."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "postal_code": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The postal code assigned to the location of the school."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "jisx0402": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The 5 digit Japanese municipality code (全国地方公共団体コード)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "prefecture": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the prefecture in Kanji.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"東京都\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "prefecture_kana": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The reading of the name of the prefecture in katakana.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"トウキョウト\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "prefecture_roman": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The \"romanized\" reading of the name of the prefecture.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"Tokyo\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "city": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the city.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"文京区\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "city_kana": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The reading of the name of the city in katakana.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"ブンキョウク\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "city_roman": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The \"romanized\" reading of the name of the city.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"Bunkyo-ku\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "street_number": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The remaining part of the address below the city level.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"本郷7-3-1\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "town": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the town.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"本郷\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "kyoto_street": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The instructional phrase (通り名) specific to Kyoto city, if any."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "block_lot_num": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The block and lot number part of the address.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"7-3-1\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "building": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The name of the building, if any."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "floor_room": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The floor and room part of the address, if any."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/SchoolFacets.json
+++ b/translations/base/v1/SchoolFacets.json
@@ -1,0 +1,98 @@
+{
+    "SchoolFacets": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`SchoolFacets`"
+                },
+                {
+                    "kind": "text",
+                    "text": " represents the facets of a school search result.\n\nIt is only available when at least one "
+                },
+                {
+                    "kind": "code",
+                    "text": "`facet_*`"
+                },
+                {
+                    "kind": "text",
+                    "text": " option is given,\nand each facet is a list of "
+                },
+                {
+                    "kind": "inline-tag",
+                    "tag": "@link",
+                    "text": "Facet",
+                    "target": {
+                        "packageName": "@ken-all/kenall",
+                        "packagePath": "src/v1/interfaces.v20250101.ts",
+                        "qualifiedName": "Facet",
+                        "pos": 11103,
+                        "transientId": null,
+                        "fileName": "/Users/moriyoshi/Source/kenall-js/src/v1/interfaces.v20250101.ts"
+                    }
+                },
+                {
+                    "kind": "text",
+                    "text": " tuples."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "area": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The facet of the area (地域)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The facet of the school type (学校種)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "establishment_type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The facet of the establishment type (設置区分)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "branch": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The facet of the branch (本分校)."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/SchoolResolverResponse.json
+++ b/translations/base/v1/SchoolResolverResponse.json
@@ -1,0 +1,65 @@
+{
+    "SchoolResolverResponse": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`SchoolResolverResponse`"
+                },
+                {
+                    "kind": "text",
+                    "text": " describes a response to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`getSchool`"
+                },
+                {
+                    "kind": "text",
+                    "text": " API call."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "version": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The version of the data, in the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "data": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The resolved school."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/SchoolSearcherOptions.json
+++ b/translations/base/v1/SchoolSearcherOptions.json
@@ -1,0 +1,145 @@
+{
+    "SchoolSearcherOptions": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "The set of options that can be passed to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`searchSchool`"
+                },
+                {
+                    "kind": "text",
+                    "text": "."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "q": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The search query.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"name:東京大学\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "offset": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The offset from which the result has to be retrieved."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "limit": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The maximum number of the items to retrieve, between 1 and 100."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facet_area": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The hierarchy of the area facet to narrow the result down to.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"/東京都/文京区\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facet_prefecture": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The hierarchy of the prefecture facet to narrow the result down to.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"/東京都\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facet_type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The hierarchy of the school type facet to narrow the result down to.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"/大学\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facet_establishment_type": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The hierarchy of the establishment type facet to narrow the result down to.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"/公立\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facet_branch": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The hierarchy of the branch facet to narrow the result down to.\n\nExample: "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"/本校\"`"
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/SchoolSearcherResponse.json
+++ b/translations/base/v1/SchoolSearcherResponse.json
@@ -1,0 +1,125 @@
+{
+    "SchoolSearcherResponse": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`SchoolSearcherResponse`"
+                },
+                {
+                    "kind": "text",
+                    "text": " describes a response to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`searchSchool`"
+                },
+                {
+                    "kind": "text",
+                    "text": " API call."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "version": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The version of the data, in the form of "
+                        },
+                        {
+                            "kind": "code",
+                            "text": "`\"YYYY-MM-DD\"`"
+                        },
+                        {
+                            "kind": "text",
+                            "text": "."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "data": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The set of the schools that match to the query."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "query": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The query that the search has been performed for."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "count": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The number of the resulting items in total."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "offset": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The offset from which the result has been retrieved."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "limit": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The number of items that have been intended, at most, to retrieve."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            },
+            "facets": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The facets of the result that form with the query.\n\nIf no facet is given, those will be unavailable and this stores null."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/base/v1/WhoamiResponse.json
+++ b/translations/base/v1/WhoamiResponse.json
@@ -1,0 +1,45 @@
+{
+    "WhoamiResponse": {
+        "comment": {
+            "summary": [
+                {
+                    "kind": "text",
+                    "text": "A "
+                },
+                {
+                    "kind": "code",
+                    "text": "`WhoamiResponse`"
+                },
+                {
+                    "kind": "text",
+                    "text": " describes a response to "
+                },
+                {
+                    "kind": "code",
+                    "text": "`whoami`"
+                },
+                {
+                    "kind": "text",
+                    "text": " API call."
+                }
+            ],
+            "blockTags": [],
+            "modifierTags": {}
+        },
+        "properties": {
+            "remote_addr": {
+                "comment": {
+                    "summary": [
+                        {
+                            "kind": "text",
+                            "text": "The IP address the request was made from."
+                        }
+                    ],
+                    "blockTags": [],
+                    "modifierTags": {}
+                }
+            }
+        },
+        "methods": {}
+    }
+}

--- a/translations/ja/v1/BusinessDayCheckResponse.json
+++ b/translations/ja/v1/BusinessDayCheckResponse.json
@@ -1,0 +1,31 @@
+{
+  "BusinessDayCheckResponse": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`BusinessDayCheckResponse` は `checkBusinessDay` API呼び出しに対するレスポンスを表します。"
+        }
+      ]
+    },
+    "properties": {
+      "result": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "問い合わせた日付が営業日（土日でも祝日でもない日）であるかどうか。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/Holiday.json
+++ b/translations/ja/v1/Holiday.json
@@ -1,0 +1,64 @@
+{
+  "Holiday": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`Holiday` オブジェクトは日本の祝日1件を表します。"
+        }
+      ]
+    },
+    "properties": {
+      "title": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "祝日の名称。\n\n例: `\"元日\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "date": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "祝日の日付。`\"YYYY-MM-DD\"` 形式。\n\n例: `\"2022-01-01\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "day_of_week": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "曜日を表す数値。`0` が日曜日、`6` が土曜日。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "day_of_week_text": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "曜日を英語の小文字で表したもの。\n\n例: `\"saturday\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/HolidaysOptions.json
+++ b/translations/ja/v1/HolidaysOptions.json
@@ -1,0 +1,53 @@
+{
+  "HolidaysOptions": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`getHolidays` に渡すことのできるオプションの集合。\n\n`year` が指定された場合、`from` と `to` は無視され、その年全体が返されます。それ以外の場合は `from` と `to` で指定された範囲が使われます。"
+        }
+      ]
+    },
+    "properties": {
+      "year": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "祝日を取得する対象の暦年。\n\n例: `2022`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "from": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "祝日を取得する範囲の開始日（この日を含む）。`\"YYYY-MM-DD\"` 形式。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "to": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "祝日を取得する範囲の終了日（この日を含む）。`\"YYYY-MM-DD\"` 形式。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/HolidaysResponse.json
+++ b/translations/ja/v1/HolidaysResponse.json
@@ -1,0 +1,31 @@
+{
+  "HolidaysResponse": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`HolidaysResponse` は `getHolidays` API呼び出しに対するレスポンスを表します。"
+        }
+      ]
+    },
+    "properties": {
+      "data": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "問い合わせた年または範囲に含まれる祝日の一覧。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/KENALL.json
+++ b/translations/ja/v1/KENALL.json
@@ -248,7 +248,123 @@
         },
         "summary": []
       },
-      "summary": []
+      "summary": [],
+      "whoami": {
+        "comment": {
+          "returns": "リクエストの送信元IPアドレスを含む {@link WhoamiResponse}。\n",
+          "summary": [
+            {
+              "kind": "text",
+              "text": "\"whoami\" API (エンドポイント: `/whoami`) を呼び出します。\n\nこのAPIはバージョン管理されていません。\n"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "getHolidays": {
+        "comment": {
+          "returns": "{@link HolidaysResponse}。\n",
+          "parameters": {
+            "options": {
+              "comment": {
+                "summary": [
+                  {
+                    "kind": "text",
+                    "text": "問い合わせ内容。`year` が指定された場合、`from` と `to` は無視され、その年全体が返されます。\n"
+                  }
+                ]
+              },
+              "summary": []
+            },
+            "summary": []
+          },
+          "summary": [
+            {
+              "kind": "text",
+              "text": "\"getHolidays\" API (エンドポイント: `/holidays`) を呼び出します。\n\nこのAPIはバージョン管理されていません。\n"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "checkBusinessDay": {
+        "comment": {
+          "returns": "{@link BusinessDayCheckResponse}。\n",
+          "parameters": {
+            "date": {
+              "comment": {
+                "summary": [
+                  {
+                    "kind": "text",
+                    "text": "確認する日付。`\"YYYY-MM-DD\"` 形式。\n"
+                  }
+                ]
+              },
+              "summary": []
+            },
+            "summary": []
+          },
+          "summary": [
+            {
+              "kind": "text",
+              "text": "\"checkBusinessDay\" API (エンドポイント: `/businessdays/check`) を呼び出します。\n\nこのAPIはバージョン管理されていません。\n"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "getSchool": {
+        "comment": {
+          "returns": "{@link SchoolResolverResponse}。\n",
+          "parameters": {
+            "schoolCode": {
+              "comment": {
+                "summary": [
+                  {
+                    "kind": "text",
+                    "text": "問い合わせ対象の13桁の学校コード。\n"
+                  }
+                ]
+              },
+              "summary": []
+            },
+            "summary": []
+          },
+          "summary": [
+            {
+              "kind": "text",
+              "text": "\"getSchool\" API (エンドポイント: `/school/{schoolCode}`) を呼び出します。\n\nこのAPIはバージョン管理されていません。\n"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "searchSchool": {
+        "comment": {
+          "returns": "{@link SchoolSearcherResponse}。\n",
+          "parameters": {
+            "options": {
+              "comment": {
+                "summary": [
+                  {
+                    "kind": "text",
+                    "text": "問い合わせ内容。\n"
+                  }
+                ]
+              },
+              "summary": []
+            },
+            "summary": []
+          },
+          "summary": [
+            {
+              "kind": "text",
+              "text": "\"searchSchool\" API (エンドポイント: `/school/?...`) を呼び出します。\n\nこのAPIはバージョン管理されていません。\n"
+            }
+          ]
+        },
+        "summary": []
+      }
     },
     "accessors": {
       "summary": []

--- a/translations/ja/v1/RemoteAddress.json
+++ b/translations/ja/v1/RemoteAddress.json
@@ -1,0 +1,42 @@
+{
+  "RemoteAddress": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`RemoteAddress` オブジェクトは、APIサーバーから見た、リクエスト元のIPアドレスを格納します。"
+        }
+      ]
+    },
+    "properties": {
+      "type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "IPアドレスの種別。\n\n* `\"v4\"` はIPv4アドレス\n* `\"v6\"` はIPv6アドレス"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "address": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "IPアドレスの文字列表現。\n\n例: `\"192.0.2.1\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/School.json
+++ b/translations/ja/v1/School.json
@@ -1,0 +1,152 @@
+{
+  "School": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`School` オブジェクトは、文部科学省によって指定された学校コード（学校コード）で識別される学校の情報を格納します。"
+        }
+      ]
+    },
+    "properties": {
+      "code": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "13桁の学校コード（学校コード）。\n\n例: `\"F113110102700\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校種コード。\n\n例: `\"F1\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "jurisdiction_prefecture_code": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "JISX0401で定義された、所管の都道府県コード。\n\n例: `\"13\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "establishment_type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "設置区分コード（設置区分）。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "branch": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "本分校コード（本分校）。`1` が本校を表します。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "name": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校名。\n\n例: `\"東京大学\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "address_raw": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校の未加工の所在地文字列。\n\n例: `\"東京都文京区本郷７－３－１\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "addresses": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "解決された学校の所在地。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "established_date": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校が設置された日付。`\"YYYY-MM-DD\"` 形式。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "abolished_date": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校が廃止された日付（`\"YYYY-MM-DD\"` 形式）。まだ存続している場合はnull。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "school_survey_number": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校調査番号。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "new_code": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "この学校を承継した学校コードの一覧（あれば）。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/SchoolAddress.json
+++ b/translations/ja/v1/SchoolAddress.json
@@ -1,0 +1,174 @@
+{
+  "SchoolAddress": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`SchoolAddress` オブジェクトは、解決された学校の所在地を格納します。"
+        }
+      ]
+    },
+    "properties": {
+      "postal_code": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校の所在地に割り当てられた郵便番号。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "jisx0402": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "5桁の全国地方公共団体コード。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "prefecture": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "都道府県の漢字名。\n\n例: `\"東京都\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "prefecture_kana": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "カタカナでの都道府県名の読み。\n\n例: `\"トウキョウト\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "prefecture_roman": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "ローマ字での都道府県名の読み。\n\n例: `\"Tokyo\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "city": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "市区町村名。\n\n例: `\"文京区\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "city_kana": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "カタカナでの市区町村名の読み。\n\n例: `\"ブンキョウク\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "city_roman": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "ローマ字での市区町村名の読み。\n\n例: `\"Bunkyo-ku\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "street_number": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "市区町村より下位の住所部分。\n\n例: `\"本郷7-3-1\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "town": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "町域名。\n\n例: `\"本郷\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "kyoto_street": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "京都市特有の通り名（通り名）。該当しない場合はnull。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "block_lot_num": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "住所の番地部分。\n\n例: `\"7-3-1\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "building": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "建物名（あれば）。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "floor_room": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "住所の階・部屋部分（あれば）。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/SchoolFacets.json
+++ b/translations/ja/v1/SchoolFacets.json
@@ -1,0 +1,64 @@
+{
+  "SchoolFacets": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`SchoolFacets` は学校検索結果のファセットを表します。\n\n少なくとも1つの `facet_*` オプションが与えられた場合にのみ利用可能で、各ファセットは Facet タプルのリストです。"
+        }
+      ]
+    },
+    "properties": {
+      "area": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "地域（地域）のファセット。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "学校種（学校種）のファセット。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "establishment_type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "設置区分（設置区分）のファセット。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "branch": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "本分校（本分校）のファセット。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/SchoolResolverResponse.json
+++ b/translations/ja/v1/SchoolResolverResponse.json
@@ -1,0 +1,42 @@
+{
+  "SchoolResolverResponse": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`SchoolResolverResponse` は `getSchool` API呼び出しに対するレスポンスを表します。"
+        }
+      ]
+    },
+    "properties": {
+      "version": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "データのバージョン。`\"YYYY-MM-DD\"` 形式。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "data": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "解決された学校。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/SchoolSearcherOptions.json
+++ b/translations/ja/v1/SchoolSearcherOptions.json
@@ -1,0 +1,108 @@
+{
+  "SchoolSearcherOptions": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`searchSchool` に渡すことのできるオプションの集合。"
+        }
+      ]
+    },
+    "properties": {
+      "q": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "検索クエリ。\n\n例: `\"name:東京大学\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "offset": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を取得するオフセット値。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "limit": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "取得する最大件数。1以上100以下の値を指定できます。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facet_area": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を絞り込む地域ファセットの階層。\n\n例: `\"/東京都/文京区\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facet_prefecture": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を絞り込む都道府県ファセットの階層。\n\n例: `\"/東京都\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facet_type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を絞り込む学校種ファセットの階層。\n\n例: `\"/大学\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facet_establishment_type": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を絞り込む設置区分ファセットの階層。\n\n例: `\"/公立\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facet_branch": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を絞り込む本分校ファセットの階層。\n\n例: `\"/本校\"`"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/SchoolSearcherResponse.json
+++ b/translations/ja/v1/SchoolSearcherResponse.json
@@ -1,0 +1,97 @@
+{
+  "SchoolSearcherResponse": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`SchoolSearcherResponse` は `searchSchool` API呼び出しに対するレスポンスを表します。"
+        }
+      ]
+    },
+    "properties": {
+      "version": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "データのバージョン。`\"YYYY-MM-DD\"` 形式。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "data": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "クエリに合致した学校の集合。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "query": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "検索が実行されたクエリ。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "count": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "合致した結果の総数。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "offset": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "結果を取得したオフセット値。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "limit": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "取得しようとした最大件数。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "facets": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "クエリに対する結果のファセット。\n\nファセットが指定されていない場合は利用できず、nullが格納されます。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}

--- a/translations/ja/v1/WhoamiResponse.json
+++ b/translations/ja/v1/WhoamiResponse.json
@@ -1,0 +1,31 @@
+{
+  "WhoamiResponse": {
+    "comment": {
+      "summary": [
+        {
+          "kind": "text",
+          "text": "`WhoamiResponse` は `whoami` API呼び出しに対するレスポンスを表します。"
+        }
+      ]
+    },
+    "properties": {
+      "remote_addr": {
+        "comment": {
+          "summary": [
+            {
+              "kind": "text",
+              "text": "リクエストの送信元となったIPアドレス。"
+            }
+          ]
+        },
+        "summary": []
+      },
+      "summary": []
+    },
+    "methods": {
+      "summary": []
+    },
+    "summary": []
+  },
+  "summary": []
+}


### PR DESCRIPTION
## Context

The published SDK documentation advertised API methods that `@ken-all/kenall` never actually implemented — samples such as `api.whoami()`, `api.getHolidays({ year: 2026 })`, and `api.checkBusinessDay('2026-01-01')` that would throw at runtime. This PR resolves that gap by **implementing the missing methods** so the SDK matches the documentation.

## What's added

| Method | Endpoint | Returns |
|---|---|---|
| `whoami()` | `/whoami` | `WhoamiResponse` |
| `getHolidays(opts?)` | `/holidays` | `HolidaysResponse` |
| `checkBusinessDay(date)` | `/businessdays/check` | `BusinessDayCheckResponse` |
| `getSchool(code)` | `/school/{code}` | `SchoolResolverResponse` |
| `searchSchool(opts)` | `/school/?…` | `SchoolSearcherResponse` |

- **`core.ts`** — five new methods following existing conventions (`./` paths, `encodeURIComponent`, param assembly mirroring `searchAddresses`). Since these endpoints are **not versioned**, they skip the `apiVersion` generic and `getValidators` dispatch and validate their schemas directly via a small shared private `validate()` helper that DRYs the `ZodError → Error("invalid response payload: …")` handling.
- **Types & schemas** — interfaces and Zod schemas are homed in the `v20250101` revision (`interfaces.v20250101.ts` / `schemas.v20250101.ts`) and re-exported from the `compatible` modules. Each earlier revision aliases only the groups that existed at that point, per the API history: whoami/holidays/business-day from **v20221101**, school from **v20240101** (matching the `@2024-01-01` OpenAPI spec); `v20220901` gets none.
- **`src/v1/index.ts` + `src/index.ts`** — new public type exports.
- **Tests** — four new vitest files (`whoami_api.ts`, `holidays_api.ts`, `businessday_api.ts`, `school_api.ts`) mirroring `bank_api.ts`, asserting exact request path + `{ method, headers, params }` and response passthrough.
- **Japanese translations** — regenerated `translations/base/*` from the new JSDoc and hand-authored all matching `translations/ja/*` type files plus the five method entries in `ja/v1/KENALL.json`.

`getCities('13')` already existed (`core.ts:120`), so no change was needed there.

## Verification

- `npm run test` — 61 passed
- `npm run lint` / `npm run check-format` — clean
- `npm run build` — `tsc` clean
- `npm run doc:gen-json && npm run doc:base && npm run doc:ja` — docs build in both languages with zero missing-translation warnings

## Follow-ups

A maintainer may want to bump `package.json` and mention the new methods in the READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)