### PR TITLE
docs: expand examples to cover every SDK method

### DIFF
--- a/examples/bundle/index.html
+++ b/examples/bundle/index.html
@@ -19,26 +19,100 @@
     </label>
     <button>送信</button>
   </form>
+  <p>
+    <button id="run-all" type="button">すべてのAPIを実行 (Run all APIs)</button>
+  </p>
   <pre id="result"></pre>
   <script type="text/javascript">
     (function (d, kenall) {
       var apiKey = '%VITE_KENALL_API_KEY%';
       var form = d.getElementById('form');
       var postalcodeElem = d.getElementById('postalcode');
+      var runAllElem = d.getElementById('run-all');
       var result = d.getElementById('result');
+      var api = new kenall.KENALL(apiKey);
+
+      // Interactive postal code → address lookup.
       form.addEventListener('submit', function (e) {
         e.preventDefault();
-        var kenallApi = new kenall.KENALL(apiKey);
-        var postalcode = postalcodeElem.value;
-        kenallApi.getAddress(postalcode).then(
+        api.getAddress(postalcodeElem.value).then(
           function (data) {
-            result.innerText = JSON.stringify(data);
+            result.innerText = JSON.stringify(data, null, 2);
           }
         ).catch(
           function (e) {
             result.innerText = e.stack;
           }
         );
+      }, false);
+
+      function log(label, value) {
+        result.innerText += label + ': ' + JSON.stringify(value) + '\n';
+      }
+
+      // Runs every available API in turn with sample inputs.
+      async function runAll() {
+        result.innerText = '';
+
+        // Postal code → address
+        var address = await api.getAddress('1000001');
+        log('getAddress', address.data[0].prefecture + address.data[0].city);
+
+        // Free-text address search
+        var foundAddresses = await api.searchAddresses({ q: '東京都 千代田区 麹町', limit: 2 });
+        log('searchAddresses', foundAddresses.count);
+
+        // Prefecture code (JIS X 0401) → cities
+        var cities = await api.getCities('13');
+        log('getCities', cities.data.map(function (city) { return city.city; }));
+
+        // Corporate number (法人番号)
+        var corporation = await api.getNTACorporateInfo('2021001052596');
+        log('getNTACorporateInfo', corporation.data.name);
+
+        var foundCorporations = await api.searchNTACorporateInfo({ query: 'ケンオール', limit: 2 });
+        log('searchNTACorporateInfo', foundCorporations.count);
+
+        // Qualified invoice issuer (適格請求書発行事業者)
+        var issuer = await api.getNTAQualifiedInvoiceIssuerInfo('T2021001052596');
+        log('getNTAQualifiedInvoiceIssuerInfo', issuer.data.name);
+
+        // Banks and branches
+        var banks = await api.getBanks();
+        log('getBanks', banks.data.length);
+
+        var bank = await api.getBank('0001');
+        log('getBank', bank.data.name);
+
+        var branches = await api.getBankBranches('0001');
+        log('getBankBranches', Object.keys(branches.data.branches).length);
+
+        var branch = await api.getBankBranch('0001', '001');
+        log('getBankBranch', branch.data.branch.name);
+
+        // The IP address the request originates from, as seen by the API
+        var me = await api.whoami();
+        log('whoami', me.remote_addr.address);
+
+        // Japanese public holidays and business-day check
+        var holidays = await api.getHolidays({ year: 2026 });
+        log('getHolidays', holidays.data.length);
+
+        var businessDay = await api.checkBusinessDay('2026-01-01');
+        log('checkBusinessDay', businessDay.result);
+
+        // School code (学校コード)
+        var school = await api.getSchool('F113110102700');
+        log('getSchool', school.data.name);
+
+        var foundSchools = await api.searchSchool({ q: 'name:東京大学', limit: 2 });
+        log('searchSchool', foundSchools.count);
+      }
+
+      runAllElem.addEventListener('click', function () {
+        runAll().catch(function (e) {
+          result.innerText += '\nError: ' + (e && e.stack ? e.stack : e);
+        });
       }, false);
     })(window.document, window.kenall);
   </script>

--- a/examples/cjs/index.js
+++ b/examples/cjs/index.js
@@ -1,18 +1,74 @@
 const { KENALL } = require('@ken-all/kenall');
 
-const postalCode = '1000001';
-const api = new KENALL(process.env.KENALL_API_KEY, { timeout: 10000 });
+const apiKey = process.env.KENALL_API_KEY;
+if (!apiKey) {
+  console.error('Please set the KENALL_API_KEY environment variable.');
+  process.exit(1);
+}
 
-api.getAddress(postalCode).then(
-  (resp) => {
-    resp.data.forEach(
-      (entry) => {
-        console.log(entry.prefecture);
-      }
-    );
-  }
-).catch(
-  (e) => {
-    console.error(e);
-  }
-);
+const api = new KENALL(apiKey, { timeout: 10000 });
+
+async function main() {
+  // Postal code → address
+  const address = await api.getAddress('1000001');
+  console.log('getAddress:', address.data[0].prefecture, address.data[0].city);
+
+  // Free-text address search
+  const foundAddresses = await api.searchAddresses({
+    q: '東京都 千代田区 麹町',
+    limit: 2,
+  });
+  console.log('searchAddresses:', foundAddresses.count, 'hit(s)');
+
+  // Prefecture code (JIS X 0401) → cities
+  const cities = await api.getCities('13');
+  console.log('getCities:', cities.data.map((city) => city.city));
+
+  // Corporate number (法人番号)
+  const corporation = await api.getNTACorporateInfo('2021001052596');
+  console.log('getNTACorporateInfo:', corporation.data.name);
+
+  // Corporate number search
+  const foundCorporations = await api.searchNTACorporateInfo({
+    query: 'ケンオール',
+    limit: 2,
+  });
+  console.log('searchNTACorporateInfo:', foundCorporations.count, 'hit(s)');
+
+  // Qualified invoice issuer (適格請求書発行事業者)
+  const issuer = await api.getNTAQualifiedInvoiceIssuerInfo('T2021001052596');
+  console.log('getNTAQualifiedInvoiceIssuerInfo:', issuer.data.name);
+
+  // Banks and branches
+  const banks = await api.getBanks();
+  console.log('getBanks:', banks.data.length, 'bank(s)');
+
+  const bank = await api.getBank('0001');
+  console.log('getBank:', bank.data.name);
+
+  const branches = await api.getBankBranches('0001');
+  console.log('getBankBranches:', Object.keys(branches.data.branches).length, 'branch(es)');
+
+  const branch = await api.getBankBranch('0001', '001');
+  console.log('getBankBranch:', branch.data.branch.name);
+
+  // The IP address the request originates from, as seen by the API
+  const me = await api.whoami();
+  console.log('whoami:', me.remote_addr.address);
+
+  // Japanese public holidays and business-day check
+  const holidays = await api.getHolidays({ year: 2026 });
+  console.log('getHolidays:', holidays.data.length, 'holiday(s)');
+
+  const businessDay = await api.checkBusinessDay('2026-01-01');
+  console.log('checkBusinessDay:', businessDay.result);
+
+  // School code (学校コード)
+  const school = await api.getSchool('F113110102700');
+  console.log('getSchool:', school.data.name);
+
+  const foundSchools = await api.searchSchool({ q: 'name:東京大学', limit: 2 });
+  console.log('searchSchool:', foundSchools.count, 'hit(s)');
+}
+
+main().catch((e) => console.error(e));

--- a/examples/esm/index.js
+++ b/examples/esm/index.js
@@ -1,17 +1,74 @@
-import { KENALL }from '@ken-all/kenall';
-const postalCode = '1000001';
-const api = new KENALL(process.env.KENALL_API_KEY, { timeout: 10000 });
+import { KENALL } from '@ken-all/kenall';
 
-api.getAddress(postalCode).then(
-  (resp) => {
-    resp.data.forEach(
-      (entry) => {
-        console.log(entry.prefecture);
-      }
-    );
-  }
-).catch(
-  (e) => {
-    console.error(e);
-  }
-);
+const apiKey = process.env.KENALL_API_KEY;
+if (!apiKey) {
+  console.error('Please set the KENALL_API_KEY environment variable.');
+  process.exit(1);
+}
+
+const api = new KENALL(apiKey, { timeout: 10000 });
+
+async function main() {
+  // Postal code → address
+  const address = await api.getAddress('1000001');
+  console.log('getAddress:', address.data[0].prefecture, address.data[0].city);
+
+  // Free-text address search
+  const foundAddresses = await api.searchAddresses({
+    q: '東京都 千代田区 麹町',
+    limit: 2,
+  });
+  console.log('searchAddresses:', foundAddresses.count, 'hit(s)');
+
+  // Prefecture code (JIS X 0401) → cities
+  const cities = await api.getCities('13');
+  console.log('getCities:', cities.data.map((city) => city.city));
+
+  // Corporate number (法人番号)
+  const corporation = await api.getNTACorporateInfo('2021001052596');
+  console.log('getNTACorporateInfo:', corporation.data.name);
+
+  // Corporate number search
+  const foundCorporations = await api.searchNTACorporateInfo({
+    query: 'ケンオール',
+    limit: 2,
+  });
+  console.log('searchNTACorporateInfo:', foundCorporations.count, 'hit(s)');
+
+  // Qualified invoice issuer (適格請求書発行事業者)
+  const issuer = await api.getNTAQualifiedInvoiceIssuerInfo('T2021001052596');
+  console.log('getNTAQualifiedInvoiceIssuerInfo:', issuer.data.name);
+
+  // Banks and branches
+  const banks = await api.getBanks();
+  console.log('getBanks:', banks.data.length, 'bank(s)');
+
+  const bank = await api.getBank('0001');
+  console.log('getBank:', bank.data.name);
+
+  const branches = await api.getBankBranches('0001');
+  console.log('getBankBranches:', Object.keys(branches.data.branches).length, 'branch(es)');
+
+  const branch = await api.getBankBranch('0001', '001');
+  console.log('getBankBranch:', branch.data.branch.name);
+
+  // The IP address the request originates from, as seen by the API
+  const me = await api.whoami();
+  console.log('whoami:', me.remote_addr.address);
+
+  // Japanese public holidays and business-day check
+  const holidays = await api.getHolidays({ year: 2026 });
+  console.log('getHolidays:', holidays.data.length, 'holiday(s)');
+
+  const businessDay = await api.checkBusinessDay('2026-01-01');
+  console.log('checkBusinessDay:', businessDay.result);
+
+  // School code (学校コード)
+  const school = await api.getSchool('F113110102700');
+  console.log('getSchool:', school.data.name);
+
+  const foundSchools = await api.searchSchool({ q: 'name:東京大学', limit: 2 });
+  console.log('searchSchool:', foundSchools.count, 'hit(s)');
+}
+
+main().catch((e) => console.error(e));

--- a/examples/typescript-cjs/index.ts
+++ b/examples/typescript-cjs/index.ts
@@ -1,18 +1,74 @@
 import { KENALL } from '@ken-all/kenall';
 
-const postalCode = '1000001';
-const api = new KENALL(process.env.KENALL_API_KEY, { timeout: 10000 });
+const apiKey = process.env.KENALL_API_KEY;
+if (!apiKey) {
+  console.error('Please set the KENALL_API_KEY environment variable.');
+  process.exit(1);
+}
 
-api.getAddress(postalCode).then(
-  (resp) => {
-    resp.data.forEach(
-      (entry) => {
-        console.log(entry.prefecture);
-      }
-    );
-  }
-).catch(
-  (e) => {
-    console.error(e);
-  }
-);
+const api = new KENALL(apiKey, { timeout: 10000 });
+
+async function main() {
+  // Postal code → address
+  const address = await api.getAddress('1000001');
+  console.log('getAddress:', address.data[0].prefecture, address.data[0].city);
+
+  // Free-text address search
+  const foundAddresses = await api.searchAddresses({
+    q: '東京都 千代田区 麹町',
+    limit: 2,
+  });
+  console.log('searchAddresses:', foundAddresses.count, 'hit(s)');
+
+  // Prefecture code (JIS X 0401) → cities
+  const cities = await api.getCities('13');
+  console.log('getCities:', cities.data.map((city) => city.city));
+
+  // Corporate number (法人番号)
+  const corporation = await api.getNTACorporateInfo('2021001052596');
+  console.log('getNTACorporateInfo:', corporation.data.name);
+
+  // Corporate number search
+  const foundCorporations = await api.searchNTACorporateInfo({
+    query: 'ケンオール',
+    limit: 2,
+  });
+  console.log('searchNTACorporateInfo:', foundCorporations.count, 'hit(s)');
+
+  // Qualified invoice issuer (適格請求書発行事業者)
+  const issuer = await api.getNTAQualifiedInvoiceIssuerInfo('T2021001052596');
+  console.log('getNTAQualifiedInvoiceIssuerInfo:', issuer.data.name);
+
+  // Banks and branches
+  const banks = await api.getBanks();
+  console.log('getBanks:', banks.data.length, 'bank(s)');
+
+  const bank = await api.getBank('0001');
+  console.log('getBank:', bank.data.name);
+
+  const branches = await api.getBankBranches('0001');
+  console.log('getBankBranches:', Object.keys(branches.data.branches).length, 'branch(es)');
+
+  const branch = await api.getBankBranch('0001', '001');
+  console.log('getBankBranch:', branch.data.branch.name);
+
+  // The IP address the request originates from, as seen by the API
+  const me = await api.whoami();
+  console.log('whoami:', me.remote_addr.address);
+
+  // Japanese public holidays and business-day check
+  const holidays = await api.getHolidays({ year: 2026 });
+  console.log('getHolidays:', holidays.data.length, 'holiday(s)');
+
+  const businessDay = await api.checkBusinessDay('2026-01-01');
+  console.log('checkBusinessDay:', businessDay.result);
+
+  // School code (学校コード)
+  const school = await api.getSchool('F113110102700');
+  console.log('getSchool:', school.data.name);
+
+  const foundSchools = await api.searchSchool({ q: 'name:東京大学', limit: 2 });
+  console.log('searchSchool:', foundSchools.count, 'hit(s)');
+}
+
+main().catch((e) => console.error(e));

--- a/examples/typescript-esm/index.ts
+++ b/examples/typescript-esm/index.ts
@@ -1,18 +1,74 @@
 import { KENALL } from '@ken-all/kenall';
 
-const postalCode = '1000001';
-const api = new KENALL(process.env.KENALL_API_KEY, { timeout: 10000 });
+const apiKey = process.env.KENALL_API_KEY;
+if (!apiKey) {
+  console.error('Please set the KENALL_API_KEY environment variable.');
+  process.exit(1);
+}
 
-api.getAddress(postalCode).then(
-  (resp) => {
-    resp.data.forEach(
-      (entry) => {
-        console.log(entry.prefecture);
-      }
-    );
-  }
-).catch(
-  (e) => {
-    console.error(e);
-  }
-);
+const api = new KENALL(apiKey, { timeout: 10000 });
+
+async function main() {
+  // Postal code → address
+  const address = await api.getAddress('1000001');
+  console.log('getAddress:', address.data[0].prefecture, address.data[0].city);
+
+  // Free-text address search
+  const foundAddresses = await api.searchAddresses({
+    q: '東京都 千代田区 麹町',
+    limit: 2,
+  });
+  console.log('searchAddresses:', foundAddresses.count, 'hit(s)');
+
+  // Prefecture code (JIS X 0401) → cities
+  const cities = await api.getCities('13');
+  console.log('getCities:', cities.data.map((city) => city.city));
+
+  // Corporate number (法人番号)
+  const corporation = await api.getNTACorporateInfo('2021001052596');
+  console.log('getNTACorporateInfo:', corporation.data.name);
+
+  // Corporate number search
+  const foundCorporations = await api.searchNTACorporateInfo({
+    query: 'ケンオール',
+    limit: 2,
+  });
+  console.log('searchNTACorporateInfo:', foundCorporations.count, 'hit(s)');
+
+  // Qualified invoice issuer (適格請求書発行事業者)
+  const issuer = await api.getNTAQualifiedInvoiceIssuerInfo('T2021001052596');
+  console.log('getNTAQualifiedInvoiceIssuerInfo:', issuer.data.name);
+
+  // Banks and branches
+  const banks = await api.getBanks();
+  console.log('getBanks:', banks.data.length, 'bank(s)');
+
+  const bank = await api.getBank('0001');
+  console.log('getBank:', bank.data.name);
+
+  const branches = await api.getBankBranches('0001');
+  console.log('getBankBranches:', Object.keys(branches.data.branches).length, 'branch(es)');
+
+  const branch = await api.getBankBranch('0001', '001');
+  console.log('getBankBranch:', branch.data.branch.name);
+
+  // The IP address the request originates from, as seen by the API
+  const me = await api.whoami();
+  console.log('whoami:', me.remote_addr.address);
+
+  // Japanese public holidays and business-day check
+  const holidays = await api.getHolidays({ year: 2026 });
+  console.log('getHolidays:', holidays.data.length, 'holiday(s)');
+
+  const businessDay = await api.checkBusinessDay('2026-01-01');
+  console.log('checkBusinessDay:', businessDay.result);
+
+  // School code (学校コード)
+  const school = await api.getSchool('F113110102700');
+  console.log('getSchool:', school.data.name);
+
+  const foundSchools = await api.searchSchool({ q: 'name:東京大学', limit: 2 });
+  console.log('searchSchool:', foundSchools.count, 'hit(s)');
+}
+
+main().catch((e) => console.error(e));


### PR DESCRIPTION
## Summary

The example projects (`esm`, `cjs`, `typescript-esm`, `typescript-cjs`, `bundle`) only demonstrated `getAddress`. This PR expands each so it exercises **every available SDK method**, following up on the methods added in #128.

Each example now runs, in turn:

- `getAddress`, `searchAddresses`
- `getCities`
- `getNTACorporateInfo`, `searchNTACorporateInfo`
- `getNTAQualifiedInvoiceIssuerInfo`
- `getBanks`, `getBank`, `getBankBranches`, `getBankBranch`
- `whoami`
- `getHolidays`, `checkBusinessDay`
- `getSchool`, `searchSchool`

logging a representative field from each response. The style is kept deliberately plain — a straight sequence of `await`ed calls, since these are demonstrations rather than production code. Each example also gains a small guard that exits early with a helpful message when `KENALL_API_KEY` is unset (which additionally makes the TypeScript examples type-check without passing `string | undefined` to the constructor). The browser `bundle` example keeps its interactive postal-code form and adds a "Run all APIs" button.

## Verification

- `examples/typescript-esm` and `examples/typescript-cjs`: `tsc --noEmit` clean
- `examples/esm` and `examples/cjs`: `node --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)