### PR TITLE
fix: support array-shaped BankBranch responses in compatible layer

### DIFF
--- a/src/v1/__tests__/bank_api.ts
+++ b/src/v1/__tests__/bank_api.ts
@@ -5,17 +5,59 @@ import { buildAugmentedFetch } from '../fetch_shim';
 
 vi.mock('../fetch_shim.js');
 
+// Builds a KENALL instance whose underlying fetch resolves to `fixture`,
+// together with the mock so the request can be asserted on.
+const mockKENALL = (fixture: unknown) => {
+  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
+  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
+  mockFetch.mockResolvedValue({
+    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
+  } as unknown as Response);
+  return { ka: new KENALL('key'), mockFetch };
+};
+
+const expectGetRequest = (
+  mockFetch: ReturnType<typeof mockKENALL>['mockFetch'],
+  path: string
+) => {
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  expect(mockFetch.mock.calls[0][0]).toBe(path);
+  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
+    method: 'GET',
+    headers: {},
+    params: {},
+  });
+};
+
+const mizuho = {
+  code: '0001',
+  name: 'みずほ',
+  katakana: 'ミズホ',
+  hiragana: 'みずほ',
+  romaji: 'mizuho',
+};
+
+const tokyoBranch = {
+  code: '001',
+  name: '東京営業部',
+  katakana: 'トウキヨウ',
+  hiragana: 'とうきょう',
+  romaji: 'toukiyou',
+};
+
+const marunouchiBranch = {
+  code: '004',
+  name: '丸の内中央',
+  katakana: 'マルノウチチユウオウ',
+  hiragana: 'まるのうちちゆうおう',
+  romaji: 'marunouchichiyuuou',
+};
+
 const banksResponseV20230901 = [
   {
     version: '2023-10-01',
     data: [
-      {
-        code: '0001',
-        name: 'みずほ',
-        katakana: 'ミズホ',
-        hiragana: 'みずほ',
-        romaji: 'mizuho',
-      },
+      mizuho,
       {
         code: '0005',
         name: '三菱UFJ',
@@ -30,141 +72,207 @@ const banksResponseV20230901 = [
 const bankResolverResponseV20230901 = [
   {
     version: '2023-10-01',
-    data: {
-      code: '0001',
-      name: 'みずほ',
-      katakana: 'ミズホ',
-      hiragana: 'みずほ',
-      romaji: 'mizuho',
-    },
+    data: mizuho,
   },
 ];
 
-const bankBranchesResponseV20230901 = [
-  {
-    version: '2023-10-01',
-    data: {
-      bank: {
-        code: '0001',
-        name: 'みずほ',
-        katakana: 'ミズホ',
-        hiragana: 'みずほ',
-        romaji: 'mizuho',
-      },
-      branches: {
-        '001': {
-          code: '001',
-          name: '東京営業部',
-          katakana: 'トウキヨウ',
-          hiragana: 'とうきょう',
-          romaji: 'toukiyou',
-        },
-        '004': {
-          code: '004',
-          name: '丸の内中央',
-          katakana: 'マルノウチチユウオウ',
-          hiragana: 'まるのうちちゆうおう',
-          romaji: 'marunouchichiyuuou',
-        },
-      },
+// Legacy (2023-09-01) shape: each branch code maps to a single BankBranch.
+const bankBranchesResponseV20230901 = {
+  version: '2023-10-01',
+  data: {
+    bank: mizuho,
+    branches: {
+      '001': tokyoBranch,
+      '004': marunouchiBranch,
     },
   },
-];
+};
 
-const bankBranchResolverResponseV20230901 = [
-  {
-    version: '2023-10-01',
-    data: {
-      bank: {
-        code: '0001',
-        name: 'みずほ',
-        katakana: 'ミズホ',
-        hiragana: 'みずほ',
-        romaji: 'mizuho',
-      },
-      branch: {
-        code: '001',
-        name: '東京営業部',
-        katakana: 'トウキヨウ',
-        hiragana: 'とうきょう',
-        romaji: 'toukiyou',
-      },
+const bankBranchResolverResponseV20230901 = {
+  version: '2023-10-01',
+  data: {
+    bank: mizuho,
+    branch: tokyoBranch,
+  },
+};
+
+// New (2025-01-01) shape: each branch code maps to an array of BankBranch,
+// because a single code may now correspond to multiple branches.
+const tokyoBranchAlt = {
+  code: '001',
+  name: '東京第二営業部',
+  katakana: 'トウキヨウダイニ',
+  hiragana: 'とうきょうだいに',
+  romaji: 'toukiyoudaini',
+};
+
+const bankBranchesResponseV20250101 = {
+  version: '2025-01-01',
+  data: {
+    bank: mizuho,
+    branches: {
+      '001': [tokyoBranch, tokyoBranchAlt],
+      '004': [marunouchiBranch],
     },
   },
-];
+};
 
-test.each(banksResponseV20230901)('getBanks method', async (fixture) => {
-  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
-  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
-  mockFetch.mockResolvedValue({
-    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
-  } as unknown as Response);
-  const ka = new KENALL('key');
+const bankBranchResolverResponseV20250101 = {
+  version: '2025-01-01',
+  data: {
+    bank: mizuho,
+    branch: [tokyoBranch, tokyoBranchAlt],
+  },
+};
+
+// A branch code that maps to an empty array (no branches). The compatible
+// layer has no first element to expose the scalar fields from.
+const bankBranchesResponseEmptyArray = {
+  version: '2025-01-01',
+  data: {
+    bank: mizuho,
+    branches: {
+      '001': [],
+    },
+  },
+};
+
+const bankBranchResolverResponseEmptyArray = {
+  version: '2025-01-01',
+  data: {
+    bank: mizuho,
+    branch: [],
+  },
+};
+
+test('getBanks method', async () => {
+  const fixture = banksResponseV20230901[0];
+  const { ka, mockFetch } = mockKENALL(fixture);
   const result = await ka.getBanks();
-  expect(mockFetch).toHaveBeenCalledTimes(1);
-  expect(mockFetch.mock.calls[0][0]).toBe('./bank');
-  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
-    method: 'GET',
-    headers: {},
-    params: {},
-  });
+  expectGetRequest(mockFetch, './bank');
   expect(result).toEqual(fixture);
 });
 
-test.each(bankResolverResponseV20230901)('getBank method', async (fixture) => {
-  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
-  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
-  mockFetch.mockResolvedValue({
-    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
-  } as unknown as Response);
-  const ka = new KENALL('key');
+test('getBank method', async () => {
+  const fixture = bankResolverResponseV20230901[0];
+  const { ka, mockFetch } = mockKENALL(fixture);
   const result = await ka.getBank('0001');
-  expect(mockFetch).toHaveBeenCalledTimes(1);
-  expect(mockFetch.mock.calls[0][0]).toBe('./bank/0001');
-  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
-    method: 'GET',
-    headers: {},
-    params: {},
-  });
+  expectGetRequest(mockFetch, './bank/0001');
   expect(result).toEqual(fixture);
 });
 
-test.each(
-  bankBranchesResponseV20230901
-)('getBankBranches method', async (fixture) => {
-  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
-  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
-  mockFetch.mockResolvedValue({
-    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
-  } as unknown as Response);
-  const ka = new KENALL('key');
+test('getBankBranches method (compatible, legacy single-branch payload)', async () => {
+  const { ka, mockFetch } = mockKENALL(bankBranchesResponseV20230901);
   const result = await ka.getBankBranches('0001');
-  expect(mockFetch).toHaveBeenCalledTimes(1);
-  expect(mockFetch.mock.calls[0][0]).toBe('./bank/0001/branches');
-  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
-    method: 'GET',
-    headers: {},
-    params: {},
-  });
-  expect(result).toEqual(fixture);
+  expectGetRequest(mockFetch, './bank/0001/branches');
+
+  expect(result.version).toBe('2023-10-01');
+  expect(result.data.bank).toEqual(mizuho);
+  // The compatible layer normalizes each single branch into a hybrid that
+  // works both as an array and as the original single object.
+  const branch = result.data.branches['001'];
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(1);
+  expect(branch[0]).toEqual(tokyoBranch);
+  expect(branch.code).toBe('001');
+  expect(branch.name).toBe('東京営業部');
 });
 
-test.each(
-  bankBranchResolverResponseV20230901
-)('getBankBranch method', async (fixture) => {
-  const mockFetch = vi.fn<ReturnType<typeof buildAugmentedFetch>>();
-  vi.mocked(buildAugmentedFetch).mockReturnValue(mockFetch);
-  mockFetch.mockResolvedValue({
-    json: vi.fn<Response['json']>().mockResolvedValue(fixture),
-  } as unknown as Response);
-  const ka = new KENALL('key');
+test('getBankBranches method (compatible, new array payload)', async () => {
+  const { ka, mockFetch } = mockKENALL(bankBranchesResponseV20250101);
+  const result = await ka.getBankBranches('0001');
+  expectGetRequest(mockFetch, './bank/0001/branches');
+
+  expect(result.version).toBe('2025-01-01');
+  const branch = result.data.branches['001'];
+  // Array payloads are preserved as arrays, while the first element's fields
+  // are also exposed on the hybrid for legacy single-object access.
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(2);
+  expect(branch[0]).toEqual(tokyoBranch);
+  expect(branch[1]).toEqual(tokyoBranchAlt);
+  expect(branch.code).toBe('001');
+  expect(branch.name).toBe('東京営業部');
+
+  const single = result.data.branches['004'];
+  expect(single).toHaveLength(1);
+  expect(single[0]).toEqual(marunouchiBranch);
+});
+
+test('getBankBranches method (compatible, empty branch array)', async () => {
+  const { ka } = mockKENALL(bankBranchesResponseEmptyArray);
+  const result = await ka.getBankBranches('0001');
+
+  // An empty array stays an empty array; there is no first element, so the
+  // scalar (legacy) fields are absent rather than fabricated.
+  const branch = result.data.branches['001'];
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(0);
+  expect(branch.code).toBeUndefined();
+});
+
+test('getBankBranches method (version-pinned payloads pass through unchanged)', async () => {
+  {
+    const { ka } = mockKENALL(bankBranchesResponseV20230901);
+    const result = await ka.getBankBranches('0001', '2023-09-01');
+    expect(result).toEqual(bankBranchesResponseV20230901);
+  }
+  {
+    const { ka } = mockKENALL(bankBranchesResponseV20250101);
+    const result = await ka.getBankBranches('0001', '2025-01-01');
+    expect(result).toEqual(bankBranchesResponseV20250101);
+  }
+});
+
+test('getBankBranch method (compatible, legacy single-branch payload)', async () => {
+  const { ka, mockFetch } = mockKENALL(bankBranchResolverResponseV20230901);
   const result = await ka.getBankBranch('0001', '001');
-  expect(mockFetch).toHaveBeenCalledTimes(1);
-  expect(mockFetch.mock.calls[0][0]).toBe('./bank/0001/branches/001');
-  expect(mockFetch.mock.calls[0][1]).toStrictEqual({
-    method: 'GET',
-    headers: {},
-    params: {},
-  });
-  expect(result).toEqual(fixture);
+  expectGetRequest(mockFetch, './bank/0001/branches/001');
+
+  expect(result.version).toBe('2023-10-01');
+  expect(result.data.bank).toEqual(mizuho);
+  const branch = result.data.branch;
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(1);
+  expect(branch[0]).toEqual(tokyoBranch);
+  expect(branch.code).toBe('001');
+  expect(branch.name).toBe('東京営業部');
+});
+
+test('getBankBranch method (compatible, new array payload)', async () => {
+  const { ka, mockFetch } = mockKENALL(bankBranchResolverResponseV20250101);
+  const result = await ka.getBankBranch('0001', '001');
+  expectGetRequest(mockFetch, './bank/0001/branches/001');
+
+  expect(result.version).toBe('2025-01-01');
+  const branch = result.data.branch;
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(2);
+  expect(branch[0]).toEqual(tokyoBranch);
+  expect(branch[1]).toEqual(tokyoBranchAlt);
+  expect(branch.code).toBe('001');
+  expect(branch.name).toBe('東京営業部');
+});
+
+test('getBankBranch method (compatible, empty branch array)', async () => {
+  const { ka } = mockKENALL(bankBranchResolverResponseEmptyArray);
+  const result = await ka.getBankBranch('0001', '001');
+
+  const branch = result.data.branch;
+  expect(Array.isArray(branch)).toBe(true);
+  expect(branch).toHaveLength(0);
+  expect(branch.code).toBeUndefined();
+});
+
+test('getBankBranch method (version-pinned payloads pass through unchanged)', async () => {
+  {
+    const { ka } = mockKENALL(bankBranchResolverResponseV20230901);
+    const result = await ka.getBankBranch('0001', '001', '2023-09-01');
+    expect(result).toEqual(bankBranchResolverResponseV20230901);
+  }
+  {
+    const { ka } = mockKENALL(bankBranchResolverResponseV20250101);
+    const result = await ka.getBankBranch('0001', '001', '2025-01-01');
+    expect(result).toEqual(bankBranchResolverResponseV20250101);
+  }
 });

--- a/src/v1/interfaces.compatible.ts
+++ b/src/v1/interfaces.compatible.ts
@@ -33,11 +33,22 @@ export type NTAQualifiedInvoiceIssuerProcess =
 export type NTAQualifiedInvoiceIssuerInfoResolverResponse =
   v20240101.NTAQualifiedInvoiceIssuerInfoResolverResponse;
 export type Bank = v20230901.Bank;
-export type BankBranch = v20230901.BankBranch;
+/**
+ * A compatible `BankBranch` is a hybrid value that can be accessed **both** as
+ * a single branch (the legacy shape, e.g. `branch.code`) **and** as an array of
+ * branches (the shape introduced in the 2025-01-01 API version, e.g.
+ * `branch[0].code`). The scalar fields mirror the first element of the array.
+ *
+ * Caveat: because the scalar fields are attached to an array, this hybrid is
+ * transparent for field access but **not** for serialization or key
+ * enumeration. `JSON.stringify(branch)` emits the array form (`[{...}]`) and
+ * drops the top-level scalar fields, and `Object.keys(branch)` yields the
+ * numeric indices alongside the scalar keys (e.g. `["0", "code", ...]`). Read
+ * fields directly rather than round-tripping the value through JSON.
+ */
+export type BankBranch = v20230901.BankBranch & v20250101.BankBranch[];
 export type BanksResponse = v20230901.BanksResponse;
 export type BankResolverResponse = v20230901.BankResolverResponse;
-export type BankBranchesResponse = v20230901.BankBranchesResponse;
-export type BankBranchResolverResponse = v20230901.BankBranchResolverResponse;
 export type RemoteAddress = v20250101.RemoteAddress;
 export type WhoamiResponse = v20250101.WhoamiResponse;
 export type Holiday = v20250101.Holiday;
@@ -572,4 +583,54 @@ export interface CityResolverResponse {
    * The set of the data that match to the query.
    */
   data: City[];
+}
+
+/**
+ * An `BankBranchesResponse` describes a response to
+ * `getBankBranches` API call.
+ * The response includes the bank and the branch data.
+ * The bank data is the same as the `BankResolverResponse`.
+ */
+export interface BankBranchesResponse {
+  /**
+   * The version of the data, in the form of `"YYYY-MM-DD"`
+   * where Y, M, and D represent digits of the year, month, and day
+   * the source data became available.
+   */
+  version: string;
+
+  /**
+   * The bank and branch data.
+   * The branches key is the bank branch code.
+   */
+  data: {
+    bank: Bank;
+    branches: {
+      [key: string]: BankBranch;
+    };
+  };
+}
+
+/**
+ * An `BankBranchResolverResponse` describes a response to
+ * `getBankBranch` API call.
+ * The response includes the bank and the branch data.
+ * The bank data is the same as the `BankResolverResponse`.
+ * The branch data is the same as the one in `BankBranchesResponse`.
+ */
+export interface BankBranchResolverResponse {
+  /**
+   * The version of the data, in the form of `"YYYY-MM-DD"`
+   * where Y, M, and D represent digits of the year, month, and day
+   * the source data became available.
+   */
+  version: string;
+
+  /**
+   * The bank and branch data.
+   */
+  data: {
+    bank: Bank;
+    branch: BankBranch;
+  };
 }

--- a/src/v1/schemas.compatible.ts
+++ b/src/v1/schemas.compatible.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import * as v20221101 from './interfaces.v20221101.js';
 import * as v20221101S from './schemas.v20221101.js';
+import * as v20230901S from './schemas.v20230901.js';
 import * as v20250101S from './schemas.v20250101.js';
 
 export const corporationSchema = v20221101S.corporationSchema;
@@ -79,6 +80,28 @@ export const citySchema = z.object({
 export const cityResolverResponseSchema = z.object({
   version: z.string(),
   data: z.array(citySchema),
+});
+
+export const bankSchema = v20230901S.bankSchema;
+export const bankBranchSchema = v20230901S.bankBranchSchema;
+export const banksResponseSchema = v20230901S.banksResponseSchema;
+export const bankBranchesResponseSchema = z.object({
+  version: z.string(),
+  data: z.object({
+    bank: bankSchema,
+    branches: z.record(
+      z.string(),
+      z.union([bankBranchSchema, z.array(bankBranchSchema)])
+    ),
+  }),
+});
+export const bankResolverResponseSchema = v20230901S.bankResolverResponseSchema;
+export const bankBranchResolverResponseSchema = z.object({
+  version: z.string(),
+  data: z.object({
+    bank: bankSchema,
+    branch: z.union([bankBranchSchema, z.array(bankBranchSchema)]),
+  }),
 });
 
 export const remoteAddressSchema = v20250101S.remoteAddressSchema;

--- a/src/v1/validators.ts
+++ b/src/v1/validators.ts
@@ -14,12 +14,18 @@ import * as v20230901S from './schemas.v20230901.js';
 import * as v20240101S from './schemas.v20240101.js';
 import * as v20250101S from './schemas.v20250101.js';
 
-export type APIVersion =
-  | '2022-09-01'
-  | '2022-11-01'
-  | '2023-09-01'
-  | '2024-01-01'
-  | '2025-01-01';
+export const API_VERSIONS = [
+  '2022-09-01',
+  '2022-11-01',
+  '2023-09-01',
+  '2024-01-01',
+  '2025-01-01',
+] as const;
+
+export type APIVersion = (typeof API_VERSIONS)[number];
+
+export const isValidAPIVersion = (version: unknown): version is APIVersion =>
+  (API_VERSIONS as readonly unknown[]).includes(version);
 
 export type AddressResolverResponseForVersion<
   T extends APIVersion | undefined,
@@ -208,6 +214,30 @@ const refillToCompatibleNTACorporateInfo = (
   hihyoji: String(data.hihyoji),
 });
 
+const isBankBranchArray = (
+  v: _v20230901.BankBranch | _v20240101.BankBranch | _v20250101.BankBranch[]
+): v is _v20250101.BankBranch[] => Array.isArray(v);
+
+const refillToCompatibleBankBranch = (
+  data: _v20230901.BankBranch | _v20240101.BankBranch | _v20250101.BankBranch[]
+): _compatible.BankBranch =>
+  isBankBranchArray(data)
+    ? (Object.assign(data, data[0]) as _compatible.BankBranch)
+    : Object.assign([data], data);
+
+const refillToCompatibleBankBranchRecords = (
+  bankToBranchRecords: Record<
+    string,
+    _v20230901.BankBranch | _v20240101.BankBranch | _v20250101.BankBranch[]
+  >
+): Record<string, _compatible.BankBranch> =>
+  Object.fromEntries(
+    Object.entries(bankToBranchRecords).map(([k, v]) => [
+      k,
+      refillToCompatibleBankBranch(v),
+    ])
+  );
+
 export const compatible = {
   validateAddressResolverResponse: (
     payload: unknown
@@ -303,12 +333,29 @@ export const compatible = {
     v20230901S.bankResolverResponseSchema.parse(payload),
   validateBankBranchesResponse: (
     payload: unknown
-  ): _compatible.BankBranchesResponse =>
-    v20230901S.bankBranchesResponseSchema.parse(payload),
+  ): _compatible.BankBranchesResponse => {
+    const _payload = compatibleS.bankBranchesResponseSchema.parse(payload);
+    return {
+      ..._payload,
+      data: {
+        ..._payload.data,
+        branches: refillToCompatibleBankBranchRecords(_payload.data.branches),
+      },
+    };
+  },
   validateBankBranchResolverResponse: (
     payload: unknown
-  ): _compatible.BankBranchResolverResponse =>
-    v20230901S.bankBranchResolverResponseSchema.parse(payload),
+  ): _compatible.BankBranchResolverResponse => {
+    const _payload =
+      compatibleS.bankBranchResolverResponseSchema.parse(payload);
+    return {
+      ..._payload,
+      data: {
+        ..._payload.data,
+        branch: refillToCompatibleBankBranch(_payload.data.branch),
+      },
+    };
+  },
 };
 
 export const v20220901 = {


### PR DESCRIPTION
Closes #130.

## Problem

As of the `2025-01-01` API version, the bank-branch endpoints changed shape: a single branch code can now map to **multiple** branches, so `data.branches[code]` (`getBankBranches`) and `data.branch` (`getBankBranch`) became `BankBranch[]` instead of a single `BankBranch`. The compatible layer still validated payloads with the old `2023-09-01` schemas, which expect exactly one branch per code, so any newer array-shaped response threw in `zod.parse()` and was rejected.

## Fix

Make the compatible layer accept **either** shape and normalize to a hybrid that keeps existing consumers working while enabling array-aware ones:

- **Schemas** (`schemas.compatible.ts`): validate branch values with `z.union([bankBranchSchema, z.array(bankBranchSchema)])`.
- **Type** (`interfaces.compatible.ts`): compatible `BankBranch` is `v20230901.BankBranch & v20250101.BankBranch[]` — simultaneously a single branch object and an array of branches. The compatible `BankBranchesResponse` / `BankBranchResolverResponse` expose this hybrid.
- **Normalization** (`validators.ts`): `refillToCompatibleBankBranch` converts either shape into the hybrid — an array gets the first element's fields copied onto it (so `branch.code` still works), a single object is wrapped in an array with its fields copied on (so it can be iterated). `refillToCompatibleBankBranchRecords` applies this across the `branches` record.
- Add the `isValidAPIVersion` type guard, backed by a single `API_VERSIONS` source of truth that also derives the `APIVersion` type.

## ⚠️ Caveat: the hybrid is not transparent to serialization

Because the scalar fields are attached to an **array**, the hybrid `BankBranch` is transparent for *field access* but not for *serialization or key enumeration*:

- `JSON.stringify(branch)` emits the array form (`[{...}]`) and **drops** the top-level scalar fields — `JSON.stringify` ignores non-index properties on arrays.
- `Object.keys(branch)` / `for..in` yields the numeric indices alongside the scalar keys, e.g. `["0", "code", "name", ...]`.

So legacy code that reads fields directly (`branch.code`, `branch.name`) keeps working unchanged, but code that **re-serializes or enumerates** a branch will see the new array shape. Read fields directly rather than round-tripping the value through JSON. This is documented in the JSDoc on the compatible `BankBranch` type.

Edge case: a branch code mapping to an **empty array** stays an empty array (`length 0`) with the scalar fields absent (`undefined`) rather than fabricated — pinned by tests.

## Tests

- `getBankBranches` / `getBankBranch` through the compatible path for both legacy single-branch payloads and new array payloads, asserting the dual hybrid access (`branch[0]` and `branch.code`).
- Version-pinned calls (`2023-09-01`, `2025-01-01`) confirm raw payloads pass through unchanged.
- Empty-array branch values.

`tsc -d --noEmit` clean, all tests pass, biome lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)