### PR TITLE
chore: re-add tslib for @rollup/plugin-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@rollup/plugin-typescript": "^12.3.0",
         "rollup": "^4.60.0",
         "rollup-plugin-license": "^3.7.0",
+        "tslib": "2.8.1",
         "typedoc": "^0.28.0",
         "typedoc-plugin-localization": "^3.1.0",
         "typescript": "^6.0.0",
@@ -2445,8 +2446,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typedoc": {
       "version": "0.28.20",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.3.0",
+    "tslib": "2.8.1",
     "rollup": "^4.60.0",
     "rollup-plugin-license": "^3.7.0",
     "typedoc": "^0.28.0",


### PR DESCRIPTION
## Summary

* `tslib` is runtime dependency of `@rollup/plugin-typescript`, but it was missed.