### PR TITLE
docs: bump latest bundle URL to 2026-07-13

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,10 +47,11 @@ function fill(form) {
 
 なお、最新のスクリプトバンドルのURLとして、以下を使うこともできます。可能な限り問題が発生しないよう配慮しますが、このURLの場所から常にバンドルをダウンロードできるかどうかは保証できません。
 
-* [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
+* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
 
 以前のバージョン:
 
+* [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
 * [https://js.kenall.jp/2026-04-15/kenall.js](https://js.kenall.jp/2026-04-15/kenall.js)
 * [https://js.kenall.jp/2026-03-31/kenall.js](https://js.kenall.jp/2026-03-31/kenall.js)
 * [https://js.kenall.jp/2025-07-29/kenall.js](https://js.kenall.jp/2025-07-29/kenall.js)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ The script bundle can be downloaded at the release page.
 
 Alternatively, you can use the following URL for the latest bundle.  Beware that we don't provide any warranty on its availability, though we'll put as much effort as possible for keeping it up.
 
-* [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
+* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
 
 Previous versions:
 
+* [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
 * [https://js.kenall.jp/2026-04-15/kenall.js](https://js.kenall.jp/2026-04-15/kenall.js)
 * [https://js.kenall.jp/2026-03-31/kenall.js](https://js.kenall.jp/2026-03-31/kenall.js)
 * [https://js.kenall.jp/2025-07-29/kenall.js](https://js.kenall.jp/2025-07-29/kenall.js)


### PR DESCRIPTION
## Summary
- Update the "latest bundle" URL in `README.md` and `README.ja.md` to `https://js.kenall.jp/2026-07-13/kenall.js`
- Move the previous `2026-05-11` URL into the "Previous versions" list

🤖 Generated with [Claude Code](https://claude.com/claude-code)