### PR TITLE
docs: bump latest bundle URL to 2026-08-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ The script bundle can be downloaded at the release page.
 
 Alternatively, you can use the following URL for the latest bundle.  Beware that we don't provide any warranty on its availability, though we'll put as much effort as possible for keeping it up.
 
-* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
+* [https://js.kenall.jp/2026-08-25/kenall.js](https://js.kenall.jp/2026-08-25/kenall.js)
 
 Previous versions:
 
+* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
 * [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
 * [https://js.kenall.jp/2026-04-15/kenall.js](https://js.kenall.jp/2026-04-15/kenall.js)
 * [https://js.kenall.jp/2026-03-31/kenall.js](https://js.kenall.jp/2026-03-31/kenall.js)


### PR DESCRIPTION
Bumps the latest bundle URL in the README to `2026-08-25` and moves the previous `2026-07-13` link into the "Previous versions" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)