### PR TITLE
docs: bump latest bundle URL to 2026-08-25 in README.ja.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,10 +47,11 @@ function fill(form) {
 
 なお、最新のスクリプトバンドルのURLとして、以下を使うこともできます。可能な限り問題が発生しないよう配慮しますが、このURLの場所から常にバンドルをダウンロードできるかどうかは保証できません。
 
-* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
+* [https://js.kenall.jp/2026-08-25/kenall.js](https://js.kenall.jp/2026-08-25/kenall.js)
 
 以前のバージョン:
 
+* [https://js.kenall.jp/2026-07-13/kenall.js](https://js.kenall.jp/2026-07-13/kenall.js)
 * [https://js.kenall.jp/2026-05-11/kenall.js](https://js.kenall.jp/2026-05-11/kenall.js)
 * [https://js.kenall.jp/2026-04-15/kenall.js](https://js.kenall.jp/2026-04-15/kenall.js)
 * [https://js.kenall.jp/2026-03-31/kenall.js](https://js.kenall.jp/2026-03-31/kenall.js)


### PR DESCRIPTION
Mirrors #141 (which updated only `README.md`) into the Japanese README:

- Point the "latest bundle" link at `https://js.kenall.jp/2026-08-25/kenall.js`
- Move the previous `2026-07-13` URL into the past-versions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)